### PR TITLE
Small UI fixes

### DIFF
--- a/frontend/src/Components/Charts/ChartAccessories/AnnotationForm.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/AnnotationForm.tsx
@@ -1,9 +1,9 @@
-import { IconButton, TextField } from "@material-ui/core"
+import { Snackbar, TextField } from "@material-ui/core"
 import { observer } from "mobx-react"
 import { FC, useState, useContext } from "react"
-import SaveIcon from '@material-ui/icons/Save';
 import Store from "../../../Interfaces/Store";
 import { useEffect } from "react";
+
 
 type Props = {
     annotationText: string;
@@ -14,25 +14,31 @@ const AnnotationForm: FC<Props> = ({ annotationText, chartI }: Props) => {
     const [formInput, setFormInput] = useState(annotationText)
     const store = useContext(Store);
 
+
     useEffect(() => {
         setFormInput(annotationText);
     }, [annotationText])
 
     return (<div>
         <TextField
-            style={{ width: "calc(100% - 30px)" }}
+            style={{ width: "100%" }}
             id="outlined-multiline-static"
-            label="Annotation"
+            label="Notes"
             multiline
             size="small"
             value={formInput}
             variant="outlined"
+            onBlur={() => {
+                if (formInput !== annotationText) {
+                    store.chartStore.changeNotation(chartI, formInput);
+                    store.configStore.openNoteSaveSuccessMessage = true;
+                }
+            }}
             onChange={(e) => { setFormInput(e.target.value) }}
         />
-        <IconButton style={{ verticalAlign: "text-top" }} size="small" onClick={() => { store.chartStore.changeNotation(chartI, formInput) }}>
-            <SaveIcon />
-        </IconButton>
-    </div>)
+
+    </div>
+    )
 }
 
 export default observer(AnnotationForm);

--- a/frontend/src/Components/Charts/ChartAccessories/AnnotationForm.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/AnnotationForm.tsx
@@ -1,4 +1,4 @@
-import { Snackbar, TextField } from "@material-ui/core"
+import { TextField } from "@material-ui/core"
 import { observer } from "mobx-react"
 import { FC, useState, useContext } from "react"
 import Store from "../../../Interfaces/Store";

--- a/frontend/src/Components/Charts/ChartAccessories/CaseCountHeader.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/CaseCountHeader.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react"
 import { FC, useCallback, useContext } from "react"
 import { CaseScaleGenerator } from "../../../HelperFunctions/Scales"
 import Store from "../../../Interfaces/Store"
-import { CaseRectWidth, DifferentialSquareWidth, largeFontSize, postop_color, preop_color, regularFontSize } from "../../../Presets/Constants"
+import { CaseRectWidth, DifferentialSquareWidth, largeFontSize, postop_color, preop_color } from "../../../Presets/Constants"
 
 type Props = {
     caseCount: number;

--- a/frontend/src/Components/Charts/ChartAccessories/CaseCountHeader.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/CaseCountHeader.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react"
 import { FC, useCallback, useContext } from "react"
 import { CaseScaleGenerator } from "../../../HelperFunctions/Scales"
 import Store from "../../../Interfaces/Store"
-import { CaseRectWidth, DifferentialSquareWidth, postop_color, preop_color } from "../../../Presets/Constants"
+import { CaseRectWidth, DifferentialSquareWidth, largeFontSize, postop_color, preop_color, regularFontSize } from "../../../Presets/Constants"
 
 type Props = {
     caseCount: number;
@@ -45,7 +45,7 @@ const CaseCountHeader: FC<Props> = ({ showComparisonRect, isFalseComparison, cas
             y={yPos + 0.5 * height}
             alignmentBaseline={"central"}
             textAnchor={"middle"}
-            fontSize="12px">
+            fontSize={store.configStore.largeFont ? largeFontSize : 12}>
             {showZero ? caseCount : (caseCount - zeroCaseNum)}
         </text>
     </g>)

--- a/frontend/src/Components/Charts/ChartAccessories/ComparisonLegend.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/ComparisonLegend.tsx
@@ -1,9 +1,11 @@
 import { timeFormat } from "d3";
 import { observer } from "mobx-react";
-import { FC } from "react";
+import { FC, useContext } from "react";
 import styled from "styled-components";
-import { DifferentialSquareWidth, preop_color, postop_color, OffsetDict } from "../../../Presets/Constants";
+import Store from "../../../Interfaces/Store";
+import { DifferentialSquareWidth, preop_color, postop_color, OffsetDict, largeFontSize, regularFontSize } from "../../../Presets/Constants";
 import { AcronymDictionary } from "../../../Presets/DataDict";
+import { BiggerFontProps } from "../../../Presets/StyledSVGComponents";
 
 type Props = {
     dimensionWidth: number;
@@ -15,6 +17,7 @@ type Props = {
 
 const ComparisonLegend: FC<Props> = ({ outcomeComparison, dimensionWidth, interventionDate, firstTotal, secondTotal }: Props) => {
     const currentOffset = OffsetDict.regular;
+    const store = useContext(Store)
     return (<g>
         <g transform="translate(0,4)">
             <rect x={0.2 * (dimensionWidth)}
@@ -34,7 +37,7 @@ const ComparisonLegend: FC<Props> = ({ outcomeComparison, dimensionWidth, interv
                 y={6}
                 alignmentBaseline={"middle"}
                 textAnchor={"start"}
-                fontSize="11px"
+                fontSize={store.configStore.largeFont ? largeFontSize : regularFontSize}
                 fill={"black"}>
                 {` ${interventionDate ? `Pre Intervene` : `True`} ${firstTotal}/${firstTotal + secondTotal}`}
             </text>
@@ -43,21 +46,23 @@ const ComparisonLegend: FC<Props> = ({ outcomeComparison, dimensionWidth, interv
                 y={18}
                 alignmentBaseline={"middle"}
                 textAnchor={"start"}
-                fontSize="11px"
+                fontSize={store.configStore.largeFont ? largeFontSize : regularFontSize}
                 fill={"black"}>
                 {`${interventionDate ? `Post Intervene` : `False`} ${secondTotal}/${firstTotal + secondTotal}`}
             </text>
         </g>
         <foreignObject x={0.0 * (dimensionWidth)} y={0} width={0.2 * dimensionWidth} height={currentOffset.top}>
-            <ComparisonDiv>{interventionDate ? `Intervention:` : `Comparing:`}</ComparisonDiv>
-            <ComparisonDiv>{interventionDate ? timeFormat("%Y-%m-%d")(new Date(interventionDate)) : (AcronymDictionary[outcomeComparison || ""]) || outcomeComparison}</ComparisonDiv>
+            <ComparisonDiv biggerFont={store.configStore.largeFont}>{interventionDate ? `Intervention:` : `Comparing:`}</ComparisonDiv>
+            <ComparisonDiv biggerFont={store.configStore.largeFont}>{interventionDate ? timeFormat("%Y-%m-%d")(new Date(interventionDate)) : (AcronymDictionary[outcomeComparison || ""]) || outcomeComparison}</ComparisonDiv>
         </foreignObject>
     </g>)
 }
 
 export default observer(ComparisonLegend)
 
-const ComparisonDiv = styled.div`
-  font-size:x-small;
+
+
+const ComparisonDiv = styled.div<BiggerFontProps>`
+  font-size:${props => props.biggerFont ? `${largeFontSize}px` : `${regularFontSize}px`};
   line-height:normal;
 `;

--- a/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisBand.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisBand.tsx
@@ -1,10 +1,11 @@
-import { FC, useCallback } from "react";
+import { FC, useCallback, useContext } from "react";
 import { observer } from "mobx-react";
 import {
     scaleBand
 } from "d3";
 import { Basic_Gray, Secondary_Gray } from "../../../Presets/Constants";
 import { AxisText, CustomAxisLine, CustomAxisLineBox } from "../../../Presets/StyledSVGComponents";
+import Store from "../../../Interfaces/Store";
 
 
 interface OwnProps {
@@ -17,7 +18,7 @@ export type Props = OwnProps;
 
 const CustomizedAxisBand: FC<Props> = ({ scaleDomain, scaleRange, scalePadding }) => {
 
-
+    const store = useContext(Store);
 
     const scale = useCallback(() => {
         const domain = JSON.parse(scaleDomain);
@@ -39,7 +40,7 @@ const CustomizedAxisBand: FC<Props> = ({ scaleDomain, scaleRange, scalePadding }
                 <g>
                     <CustomAxisLine x1={x1} x2={x2} />
                     <CustomAxisLineBox x={x1} width={x2 - x1} fill={ind % 2 === 1 ? Secondary_Gray : Basic_Gray} />
-                    <AxisText x={x1 + 0.5 * (x2 - x1)}>{number}</AxisText>
+                    <AxisText biggerFont={store.configStore.largeFont} x={x1 + 0.5 * (x2 - x1)}>{number}</AxisText>
                 </g>
             )
 

--- a/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from "react";
+import { FC, useCallback, useContext } from "react";
 import { observer } from "mobx-react";
 import {
     ScaleOrdinal,
@@ -6,6 +6,7 @@ import {
 } from "d3";
 import { Basic_Gray, Secondary_Gray } from "../../../Presets/Constants";
 import { AxisText, CustomAxisLine, CustomAxisLineBox } from "../../../Presets/StyledSVGComponents";
+import Store from "../../../Interfaces/Store";
 
 interface OwnProps {
     scaleDomain: string;
@@ -15,7 +16,7 @@ interface OwnProps {
 export type Props = OwnProps;
 
 const CustomizedAxisOrdinal: FC<Props> = ({ numberList, scaleDomain, scaleRange }) => {
-
+    const store = useContext(Store);
     const scale = useCallback(() => {
         const domain = JSON.parse(scaleDomain);
         const range = JSON.parse(scaleRange)
@@ -36,7 +37,7 @@ const CustomizedAxisOrdinal: FC<Props> = ({ numberList, scaleDomain, scaleRange 
                     <g>
                         <CustomAxisLine x1={x1} x2={x2} />
                         <CustomAxisLineBox x={x1} width={x2 - x1} fill={ind % 2 === 1 ? Secondary_Gray : Basic_Gray} />
-                        <AxisText x={x1 + 0.5 * (x2 - x1)}>{numberOb.num}</AxisText>
+                        <AxisText biggerFont={store.configStore.largeFont} x={x1 + 0.5 * (x2 - x1)}>{numberOb.num}</AxisText>
                     </g>)
             } else { return <></> }
         })}

--- a/frontend/src/Components/Charts/ChartAccessories/DualColorLegend.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/DualColorLegend.tsx
@@ -29,17 +29,17 @@ const DualColorLegend: FC<Props> = ({ dimensionWidth }) => {
             x={0.7 * (dimensionWidth)}
             y={10}
             width={0.2 * (dimensionWidth)}
-            height={7.5}
+            height={8}
             fill="url(#gradient1)" />
         <rect
             x={0.7 * (dimensionWidth)}
-            y={17.5}
+            y={18}
             width={0.2 * (dimensionWidth)}
-            height={7.5}
+            height={8}
             fill="url(#gradient2)" />
         <text
-            x={0.7 * (dimensionWidth)}
-            y={17.5}
+            x={0.7 * (dimensionWidth) - 2}
+            y={18}
             alignmentBaseline={"middle"}
             textAnchor={"end"}
             fontSize="11px"
@@ -47,8 +47,8 @@ const DualColorLegend: FC<Props> = ({ dimensionWidth }) => {
             0%
         </text>
         <text
-            x={0.9 * (dimensionWidth)}
-            y={17.5}
+            x={0.9 * (dimensionWidth) + 2}
+            y={18}
             alignmentBaseline={"middle"}
             textAnchor={"start"}
             fontSize="11px"
@@ -66,7 +66,7 @@ const DualColorLegend: FC<Props> = ({ dimensionWidth }) => {
         </text>
         <text
             x={0.8 * (dimensionWidth)}
-            y={7.5}
+            y={8}
             alignmentBaseline={"baseline"}
             textAnchor={"middle"}
             fontSize="11px"

--- a/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairBar.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairBar.tsx
@@ -25,7 +25,11 @@ const ExtraPairBar: FC<Props> = ({ secondaryDataSet, dataSet, aggregationScaleDo
     }, [aggregationScaleDomain, aggregationScaleRange])
 
     const valueScale = useCallback(() => {
-        const valueScale = scaleLinear().domain([0, max(Object.values(dataSet))]).range([0, ExtraPairWidth.BarChart])
+        let maxVal = max(Object.values(dataSet))
+        if (secondaryDataSet) {
+            maxVal = max(Object.values(secondaryDataSet).concat([maxVal]))
+        }
+        const valueScale = scaleLinear().domain([0, maxVal]).range([0, ExtraPairWidth.BarChart])
         return valueScale
     }, [dataSet])
 

--- a/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairBasic.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairBasic.tsx
@@ -1,8 +1,9 @@
-import { FC, useCallback } from "react";
+import { FC, useCallback, useContext } from "react";
 import { scaleLinear, format, interpolateGreys, scaleBand } from "d3";
 import { observer } from "mobx-react";
-import { Basic_Gray, ExtraPairWidth, greyScaleRange } from "../../../../Presets/Constants";
+import { Basic_Gray, ExtraPairWidth, greyScaleRange, largeFontSize, regularFontSize } from "../../../../Presets/Constants";
 import { Tooltip } from "@material-ui/core";
+import Store from "../../../../Interfaces/Store";
 
 interface OwnProps {
     dataSet: any[];
@@ -14,7 +15,7 @@ interface OwnProps {
 export type Props = OwnProps;
 
 const ExtraPairBasic: FC<Props> = ({ secondaryDataSet, dataSet, aggregationScaleRange, aggregationScaleDomain }: Props) => {
-
+    const store = useContext(Store);
 
     const aggregationScale = useCallback(() => {
         const domain = JSON.parse(aggregationScaleDomain).map((d: number) => d.toString());
@@ -57,7 +58,7 @@ const ExtraPairBasic: FC<Props> = ({ secondaryDataSet, dataSet, aggregationScale
                                 opacity={!isNaN(dataVal.calculated) ? 1 : 0}
                                 fill={valueScale(dataVal.calculated) > 0.4 ? "white" : "black"}
                                 alignmentBaseline={"central"}
-                                fontSize="12px"
+                                fontSize={store.configStore.largeFont ? largeFontSize : 12}
                                 textAnchor={"middle"}>{Math.round(dataVal.calculated * 100) === 0 && dataVal.calculated > 0 ? "<1%" : format(".0%")(dataVal.calculated)}</text>
                         </g>
                     )
@@ -90,7 +91,7 @@ const ExtraPairBasic: FC<Props> = ({ secondaryDataSet, dataSet, aggregationScale
                                 opacity={!isNaN(dataVal.calculated) ? 1 : 0}
                                 fill={valueScale(dataVal.calculated) > 0.4 ? "white" : "black"}
                                 alignmentBaseline={"central"}
-                                fontSize="12px"
+                                fontSize={store.configStore.largeFont ? largeFontSize : 12}
                                 textAnchor={"middle"}>{Math.round(dataVal.calculated * 100) === 0 && dataVal.calculated > 0 ? "<1%" : format(".0%")(dataVal.calculated)}</text>
                         </g>
                     )

--- a/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairBasic.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairBasic.tsx
@@ -1,7 +1,7 @@
 import { FC, useCallback, useContext } from "react";
 import { scaleLinear, format, interpolateGreys, scaleBand } from "d3";
 import { observer } from "mobx-react";
-import { Basic_Gray, ExtraPairWidth, greyScaleRange, largeFontSize, regularFontSize } from "../../../../Presets/Constants";
+import { Basic_Gray, ExtraPairWidth, greyScaleRange, largeFontSize } from "../../../../Presets/Constants";
 import { Tooltip } from "@material-ui/core";
 import Store from "../../../../Interfaces/Store";
 

--- a/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/GeneratorExtraPair.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/GeneratorExtraPair.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react";
 import styled from "styled-components";
 import { max, format } from "d3";
 import { ExtraPairPoint } from "../../../../Interfaces/Types/DataTypes";
-import { ExtraPairPadding, ExtraPairWidth, HGB_HIGH_STANDARD, HGB_LOW_STANDARD, largeFontSize, OffsetDict, regularFontSize } from "../../../../Presets/Constants";
+import { Basic_Gray, ExtraPairPadding, ExtraPairWidth, HGB_HIGH_STANDARD, HGB_LOW_STANDARD, largeFontSize, OffsetDict, regularFontSize } from "../../../../Presets/Constants";
 import { AcronymDictionary } from "../../../../Presets/DataDict";
 import { useContext } from "react";
 import Store from "../../../../Interfaces/Store";
@@ -62,13 +62,14 @@ const ExtraPairPlotGenerator: FC<Props> = ({ extraPairDataSet, secondaryExtraPai
             <Tooltip title={tooltipText}>
                 <ExtraPairText
                     x={spacing / 2}
-                    y={height - currentOffset.bottom + 20}
+                    y={height - currentOffset.bottom + 28}
                     biggerFont={store.configStore.largeFont}
                     onClick={() => {
                         store.chartStore.removeExtraPair(chartId, nameInput)
                     }}
 
-                >{labelInput}</ExtraPairText>
+                >{labelInput}
+                    <tspan fontSize={10} fill={Basic_Gray} x={spacing / 2} dy="1.2em">x</tspan></ExtraPairText>
             </Tooltip>)
 
 
@@ -144,6 +145,6 @@ export default observer(ExtraPairPlotGenerator);
 const ExtraPairText = styled(`text`) <BiggerFontProps>`
   font-size: ${props => props.biggerFont ? `${largeFontSize}px` : `${regularFontSize}px`};
   text-anchor: middle;
-  alignment-baseline:hanging;
+  alignment-baseline:bottom;
   cursor:pointer;
 `

--- a/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/GeneratorExtraPair.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/GeneratorExtraPair.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react";
 import styled from "styled-components";
 import { max, format } from "d3";
 import { ExtraPairPoint } from "../../../../Interfaces/Types/DataTypes";
-import { ExtraPairPadding, ExtraPairWidth, HGB_HIGH_STANDARD, HGB_LOW_STANDARD, OffsetDict } from "../../../../Presets/Constants";
+import { ExtraPairPadding, ExtraPairWidth, HGB_HIGH_STANDARD, HGB_LOW_STANDARD, largeFontSize, OffsetDict, regularFontSize } from "../../../../Presets/Constants";
 import { AcronymDictionary } from "../../../../Presets/DataDict";
 import { useContext } from "react";
 import Store from "../../../../Interfaces/Store";
@@ -11,6 +11,7 @@ import ExtraPairViolin from "./ExtraPairViolin";
 import ExtraPairBar from "./ExtraPairBar";
 import ExtraPairBasic from "./ExtraPairBasic";
 import { Tooltip } from "@material-ui/core";
+import { BiggerFontProps } from "../../../../Presets/StyledSVGComponents";
 
 
 interface OwnProps {
@@ -62,6 +63,7 @@ const ExtraPairPlotGenerator: FC<Props> = ({ extraPairDataSet, secondaryExtraPai
                 <ExtraPairText
                     x={spacing / 2}
                     y={height - currentOffset.bottom + 20}
+                    biggerFont={store.configStore.largeFont}
                     onClick={() => {
                         store.chartStore.removeExtraPair(chartId, nameInput)
                     }}
@@ -137,8 +139,10 @@ const ExtraPairPlotGenerator: FC<Props> = ({ extraPairDataSet, secondaryExtraPai
 
 export default observer(ExtraPairPlotGenerator);
 
-const ExtraPairText = styled(`text`)`
-  font-size: 11px;
+
+
+const ExtraPairText = styled(`text`) <BiggerFontProps>`
+  font-size: ${props => props.biggerFont ? `${largeFontSize}px` : `${regularFontSize}px`};
   text-anchor: middle;
   alignment-baseline:hanging;
   cursor:pointer;

--- a/frontend/src/Components/Charts/ChartAccessories/HeatMapAxis.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/HeatMapAxis.tsx
@@ -49,11 +49,13 @@ const HeatMapAxis: FC<Props> = ({ svg, currentOffset, extraPairTotalWidth, xVals
         )
         .call(aggregationLabel as any)
         .selectAll("text")
+        .attr("font-size", store.configStore.largeFont ? largeFontSize : regularFontSize)
         .attr("transform", `translate(-${CaseRectWidth + 2},0)`)
         .attr("cursor", "pointer")
         .on("click", (e, d: any) => {
             store.selectionStore.selectSet(xAggregationOption, d.toString(), !e.shiftKey)
         })
+
 
     svgSelection
         .select(".axes")
@@ -64,12 +66,13 @@ const HeatMapAxis: FC<Props> = ({ svg, currentOffset, extraPairTotalWidth, xVals
         )
         .call(valueLabel as any)
         .call(g => g.select(".domain").remove())
-        .call(g => g.selectAll(".tick").selectAll("line").remove());
+        .call(g => g.selectAll(".tick").selectAll("line").remove())
+        .call(g => g.selectAll(".tick").selectAll("text").attr("font-size", store.configStore.largeFont ? largeFontSize : regularFontSize));
 
     svgSelection
         .select(".x-label")
         .attr("x", (dimensionWidth - extraPairTotalWidth) * 0.5)
-        .attr("y", dimensionHeight - currentOffset.bottom + 20)
+        .attr("y", dimensionHeight - currentOffset.bottom + 25)
         .attr("alignment-baseline", "hanging")
         .attr("font-size", store.configStore.largeFont ? largeFontSize : regularFontSize)
         .attr("text-anchor", "middle")
@@ -80,8 +83,8 @@ const HeatMapAxis: FC<Props> = ({ svg, currentOffset, extraPairTotalWidth, xVals
 
     svgSelection
         .select(".y-label")
-        .attr("y", dimensionHeight - currentOffset.bottom + 20)
-        .attr("x", 0)
+        .attr("y", dimensionHeight - currentOffset.bottom + 25)
+        .attr("x", 20)
         .attr("font-size", store.configStore.largeFont ? largeFontSize : regularFontSize)
         .attr("text-anchor", "start")
         .attr("alignment-baseline", "hanging")

--- a/frontend/src/Components/Charts/ChartAccessories/SingleColorLegend.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/SingleColorLegend.tsx
@@ -20,11 +20,11 @@ const SingleColorLegend: FC<Props> = ({ dimensionWidth }) => {
             x={0.7 * (dimensionWidth)}
             y={0}
             width={0.2 * (dimensionWidth)}
-            height={15}
+            height={16}
             fill="url(#gradient1)" />
         <text
-            x={0.7 * (dimensionWidth)}
-            y={7.5}
+            x={0.7 * (dimensionWidth) - 2}
+            y={8}
             alignmentBaseline={"middle"}
             textAnchor={"end"}
             fontSize="11px"
@@ -32,8 +32,8 @@ const SingleColorLegend: FC<Props> = ({ dimensionWidth }) => {
             0%
         </text>
         <text
-            x={0.9 * (dimensionWidth)}
-            y={7.5}
+            x={0.9 * (dimensionWidth) + 2}
+            y={8}
             alignmentBaseline={"middle"}
             textAnchor={"start"}
             fontSize="11px"

--- a/frontend/src/Components/Charts/CostBarChart/WrapperCostBar.tsx
+++ b/frontend/src/Components/Charts/CostBarChart/WrapperCostBar.tsx
@@ -1,4 +1,4 @@
-import { Container, FormControl, FormHelperText, Grid, IconButton, Menu, MenuItem, Switch, Tooltip } from "@material-ui/core";
+import { Container, FormControl, IconButton, Menu, MenuItem, Switch, Tooltip } from "@material-ui/core";
 import axios from "axios";
 import { sum } from "d3";
 import { observer } from "mobx-react";

--- a/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
@@ -240,8 +240,9 @@ const DumbbellChart: FC<Props> = ({ data, valueToVisualize, dimensionHeight, dim
     svgSelection.select('.axes')
         .select(".x-axis")
         .attr("transform", `translate(${currentOffset.left}, 0)`)
-        .call(testLabel as any);
-
+        .call(testLabel as any)
+        .selectAll("text")
+        .attr("font-size", store.configStore.largeFont ? largeFontSize : regularFontSize);
 
 
     svgSelection

--- a/frontend/src/Components/Charts/HeatMap/SingleHeatRow.tsx
+++ b/frontend/src/Components/Charts/HeatMap/SingleHeatRow.tsx
@@ -1,4 +1,4 @@
-import { format, interpolateGreys, interpolateReds, ScaleBand, scaleBand } from "d3";
+import { format, interpolateGreys, interpolateReds, ScaleBand } from "d3";
 import { observer } from "mobx-react";
 import { FC, useCallback, useContext } from "react";
 import { HeatmapColorScale, HeatmapGreyScale, ValueScaleGeneratorFromDomainRange } from "../../../HelperFunctions/Scales";

--- a/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
@@ -130,7 +130,9 @@ const ScatterPlot: FC<Props> = ({ xAggregationOption, xMax, xMin, yMax, yMin, yV
         .select(".y-axis")
         .attr("transform", `translate(${currentOffset.left}, 0)`)
         .attr('display', null)
-        .call(yAxisLabel as any);
+        .call(yAxisLabel as any)
+        .selectAll("text")
+        .attr("font-size", store.configStore.largeFont ? largeFontSize : regularFontSize);
 
     svgSelection
         .select(".axes")
@@ -149,7 +151,19 @@ const ScatterPlot: FC<Props> = ({ xAggregationOption, xMax, xMin, yMax, yMin, yV
     if (xAggregationOption === "CELL_SAVER_ML") {
         svgSelection.select('.axes')
             .select(".x-axis")
-            .call(xAxisLabel as any);
+            .call(xAxisLabel as any)
+            .selectAll("text")
+            .attr("font-size", store.configStore.largeFont ? largeFontSize : regularFontSize);
+    }
+    else {
+        svgSelection.select('.axes')
+            .select(".x-axis")
+            .selectAll(".tick")
+            .remove();
+        svgSelection.select('.axes')
+            .select(".x-axis")
+            .selectAll(".domain")
+            .remove();
     }
 
 

--- a/frontend/src/Components/Charts/ScatterPlot/WrapperScatter.tsx
+++ b/frontend/src/Components/Charts/ScatterPlot/WrapperScatter.tsx
@@ -1,4 +1,4 @@
-import { Container, Grid } from "@material-ui/core";
+import { Container } from "@material-ui/core";
 import { observer } from "mobx-react";
 import { FC, useContext, useLayoutEffect, useRef, useState } from "react";
 import { DataContext } from "../../../App";

--- a/frontend/src/Components/Modals/SaveStateModal.tsx
+++ b/frontend/src/Components/Modals/SaveStateModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, FormControlLabel, FormGroup, Radio, RadioGroup, Snackbar, Switch, TextField } from "@material-ui/core";
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, FormControlLabel, FormGroup, Radio, RadioGroup, Snackbar, TextField } from "@material-ui/core";
 import { Alert } from "@material-ui/lab";
 import { observer } from "mobx-react";
 import { FC, useState, useContext } from "react";

--- a/frontend/src/Components/Utilities/DetailView/DetailView.tsx
+++ b/frontend/src/Components/Utilities/DetailView/DetailView.tsx
@@ -1,4 +1,4 @@
-import { Container, Divider } from "@material-ui/core";
+import { Divider } from "@material-ui/core";
 import { observer } from "mobx-react";
 import { FC, useContext } from "react";
 import Store from "../../../Interfaces/Store";
@@ -9,8 +9,7 @@ import CaseList from "./CaseList";
 const DetailView: FC = () => {
 
     const store = useContext(Store);
-    const { currentBrushedPatientGroup } = store.state
-    const styles = useStyles();
+    const { currentBrushedPatientGroup } = store.state;
 
     return (
         <div

--- a/frontend/src/Components/Utilities/FilterInterface/FilterBoard.tsx
+++ b/frontend/src/Components/Utilities/FilterInterface/FilterBoard.tsx
@@ -1,11 +1,11 @@
-import { Container, Divider, Drawer, Grid, IconButton, List, ListItem, ListItemSecondaryAction, ListItemText, Tooltip } from "@material-ui/core";
+import { Divider, Drawer, IconButton, List, ListItem, ListItemSecondaryAction, ListItemText, Tooltip } from "@material-ui/core";
 import DateFnsUtils from '@date-io/date-fns';
 import CloseIcon from '@material-ui/icons/Close';
 import { MuiPickersUtilsProvider, KeyboardDatePicker } from "@material-ui/pickers";
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import { observer } from "mobx-react";
-import { FC, useContext, useEffect, useState } from "react";
-import { AcronymDictionary, OutcomeOptions } from "../../../Presets/DataDict"
+import { FC, useContext, useState } from "react";
+import { AcronymDictionary } from "../../../Presets/DataDict"
 import Store from "../../../Interfaces/Store";
 import ComponentRangePicker from "./ComponentRangePicker";
 import { Title, useStyles } from "../../../Presets/StyledComponents";
@@ -44,6 +44,28 @@ const FilterBoard: FC = () => {
         return canReset
     }
 
+    const enableClearAll = () => {
+        if (rawDateRange[0] !== defaultState.rawDateRange[0] || rawDateRange[1] !== defaultState.rawDateRange[1]) {
+            return true
+        }
+        if (outcomeFilter.length > 0) {
+            return true
+        }
+        if (!(surgeryUrgencySelection[0] && surgeryUrgencySelection[1] && surgeryUrgencySelection[2])) {
+            return true
+        }
+        if (currentSelectPatientGroup.length > 0 || currentOutputFilterSet.length > 0) {
+            return true
+        }
+        if (checkIfCanReset(testValueFilter)) {
+            return true
+        }
+        if (checkIfCanReset(bloodComponentFilter)) {
+            return true
+        }
+        return false;
+    }
+
     return <Drawer
         className={styles.drawer}
         anchor="left"
@@ -53,11 +75,22 @@ const FilterBoard: FC = () => {
         onClose={() => { store.configStore.openDrawer = false }}
         open={store.configStore.openDrawer}>
 
-        <IconButton style={{ alignSelf: "end" }} onClick={() => { store.configStore.openDrawer = false }}>
-            Filter
-            <ChevronLeftIcon />
-        </IconButton>
 
+        <div style={{ alignSelf: "end" }}>
+
+
+            <Title style={{ paddingRight: "20px" }}>
+                Filter
+            </Title>
+            <IconButton disabled={!enableClearAll()} onClick={() => { store.configStore.clearAllFilter() }}>
+                <Tooltip title="Clear All Filters">
+                    <ClearAllIcon />
+                </Tooltip>
+            </IconButton>
+            <IconButton onClick={() => { store.configStore.openDrawer = false }}>
+                <ChevronLeftIcon />
+            </IconButton>
+        </div>
         <Divider />
         <List dense>
             <ListItem>
@@ -65,12 +98,14 @@ const FilterBoard: FC = () => {
                     Pick Date Range
                 </Title>} />
                 <ListItemSecondaryAction>
-                    <Tooltip title="Reset">
-                        <IconButton onClick={resetDateFilter}
-                            disabled={(rawDateRange[0] === defaultState.rawDateRange[0]) && (rawDateRange[1] === defaultState.rawDateRange[1])}>
+
+                    <IconButton onClick={resetDateFilter}
+                        disabled={(rawDateRange[0] === defaultState.rawDateRange[0]) && (rawDateRange[1] === defaultState.rawDateRange[1])}>
+                        <Tooltip title="Reset">
                             <ClearAllIcon />
-                        </IconButton>
-                    </Tooltip>
+                        </Tooltip>
+                    </IconButton>
+
                 </ListItemSecondaryAction>
             </ListItem>
             <ListItem>
@@ -117,14 +152,16 @@ const FilterBoard: FC = () => {
                     Outcome / Intervention Filter
                 </Title>} />
                 <ListItemSecondaryAction>
-                    <Tooltip title="Clear All">
-                        <IconButton
-                            onClick={() => { store.configStore.changeOutcomeFilter([]) }}
-                            disabled={outcomeFilter.length === 0}
-                        >
+
+                    <IconButton
+                        onClick={() => { store.configStore.changeOutcomeFilter([]) }}
+                        disabled={outcomeFilter.length === 0}
+                    >
+                        <Tooltip title="Clear">
                             <ClearAllIcon />
-                        </IconButton>
-                    </Tooltip>
+                        </Tooltip>
+                    </IconButton>
+
                 </ListItemSecondaryAction>
             </ListItem>
             <OutcomeChipGroup />
@@ -134,14 +171,16 @@ const FilterBoard: FC = () => {
             <ListItem>
                 <ListItemText primary={<Title>Surgery Urgency Filter</Title>} />
                 <ListItemSecondaryAction>
-                    <Tooltip title="Clear All">
-                        <IconButton
-                            onClick={() => { store.configStore.changeSurgeryUrgencySelection([true, true, true]) }}
-                            disabled={surgeryUrgencySelection[0] && surgeryUrgencySelection[1] && surgeryUrgencySelection[2]}
-                        >
+
+                    <IconButton
+                        onClick={() => { store.configStore.changeSurgeryUrgencySelection([true, true, true]) }}
+                        disabled={surgeryUrgencySelection[0] && surgeryUrgencySelection[1] && surgeryUrgencySelection[2]}
+                    >
+                        <Tooltip title="Clear">
                             <ClearAllIcon />
-                        </IconButton>
-                    </Tooltip>
+                        </Tooltip>
+                    </IconButton>
+
                 </ListItemSecondaryAction>
             </ListItem>
             <SurgeryUrgencyChipGroup />
@@ -151,12 +190,14 @@ const FilterBoard: FC = () => {
             <ListItem>
                 <ListItemText primary={<Title>Selection Filter</Title>} />
                 <ListItemSecondaryAction>
-                    <Tooltip title="Clear All">
-                        <IconButton onClick={() => { store.selectionStore.clearSelectionFilter() }}
-                            disabled={currentSelectPatientGroup.length === 0 && currentOutputFilterSet.length === 0}>
+
+                    <IconButton onClick={() => { store.selectionStore.clearSelectionFilter() }}
+                        disabled={currentSelectPatientGroup.length === 0 && currentOutputFilterSet.length === 0}>
+                        <Tooltip title="Clear All">
                             <ClearAllIcon />
-                        </IconButton>
-                    </Tooltip>
+                        </Tooltip>
+                    </IconButton>
+
                 </ListItemSecondaryAction>
             </ListItem>
             {currentSelectPatientGroup.length > 0 ? (
@@ -191,12 +232,14 @@ const FilterBoard: FC = () => {
             <ListItem>
                 <ListItemText primary={<Title>Blood Component Filter</Title>} />
                 <ListItemSecondaryAction>
-                    <Tooltip title="Reset">
-                        <IconButton onClick={() => { store.configStore.resetBloodFilter() }}
-                            disabled={!checkIfCanReset(bloodComponentFilter)}>
+
+                    <IconButton onClick={() => { store.configStore.resetBloodFilter() }}
+                        disabled={!checkIfCanReset(bloodComponentFilter)}>
+                        <Tooltip title="Reset">
                             <ClearAllIcon />
-                        </IconButton>
-                    </Tooltip>
+                        </Tooltip>
+                    </IconButton>
+
                 </ListItemSecondaryAction>
             </ListItem>
             {BloodComponentOptions.map((d) => {
@@ -207,12 +250,14 @@ const FilterBoard: FC = () => {
             <ListItem>
                 <ListItemText primary={<Title>Test Value Filter</Title>} />
                 <ListItemSecondaryAction>
-                    <Tooltip title="Reset">
-                        <IconButton onClick={() => { store.configStore.resetTestValueFilter() }}
-                            disabled={!checkIfCanReset(testValueFilter)}>
+
+                    <IconButton onClick={() => { store.configStore.resetTestValueFilter() }}
+                        disabled={!checkIfCanReset(testValueFilter)}>
+                        <Tooltip title="Reset">
                             <ClearAllIcon />
-                        </IconButton>
-                    </Tooltip>
+                        </Tooltip>
+                    </IconButton>
+
                 </ListItemSecondaryAction>
             </ListItem>
             {ScatterYOptions.map((d) => {

--- a/frontend/src/Components/Utilities/FilterInterface/FilterBoard.tsx
+++ b/frontend/src/Components/Utilities/FilterInterface/FilterBoard.tsx
@@ -1,9 +1,11 @@
 import { Container, Divider, Drawer, Grid, IconButton, List, ListItem, ListItemSecondaryAction, ListItemText, Tooltip } from "@material-ui/core";
 import DateFnsUtils from '@date-io/date-fns';
+import CloseIcon from '@material-ui/icons/Close';
 import { MuiPickersUtilsProvider, KeyboardDatePicker } from "@material-ui/pickers";
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import { observer } from "mobx-react";
 import { FC, useContext, useEffect, useState } from "react";
+import { AcronymDictionary, OutcomeOptions } from "../../../Presets/DataDict"
 import Store from "../../../Interfaces/Store";
 import ComponentRangePicker from "./ComponentRangePicker";
 import { Title, useStyles } from "../../../Presets/StyledComponents";
@@ -12,13 +14,14 @@ import ClearAllIcon from '@material-ui/icons/ClearAll';
 import { defaultState } from "../../../Interfaces/DefaultState";
 import OutcomeChipGroup from "./OutcomeChipGroup";
 import SurgeryUrgencyChipGroup from "./SurgeryUrgencyChipGroup";
+import { SelectSet } from "../../../Interfaces/Types/SelectionTypes";
 
 
 const FilterBoard: FC = () => {
 
     const store = useContext(Store);
     const styles = useStyles()
-    const { rawDateRange, outcomeFilter, surgeryUrgencySelection, bloodComponentFilter, testValueFilter } = store.state;
+    const { rawDateRange, outcomeFilter, surgeryUrgencySelection, currentSelectPatientGroup, currentOutputFilterSet, bloodComponentFilter, testValueFilter } = store.state;
     const [beginDate, setBeginDate] = useState<number | null>(rawDateRange[0]);
     const [endDate, setEndDate] = useState<number | null>(rawDateRange[1]);
 
@@ -142,6 +145,46 @@ const FilterBoard: FC = () => {
                 </ListItemSecondaryAction>
             </ListItem>
             <SurgeryUrgencyChipGroup />
+        </List>
+
+        <List dense>
+            <ListItem>
+                <ListItemText primary={<Title>Selection Filter</Title>} />
+                <ListItemSecondaryAction>
+                    <Tooltip title="Clear All">
+                        <IconButton onClick={() => { store.selectionStore.clearSelectionFilter() }}
+                            disabled={currentSelectPatientGroup.length === 0 && currentOutputFilterSet.length === 0}>
+                            <ClearAllIcon />
+                        </IconButton>
+                    </Tooltip>
+                </ListItemSecondaryAction>
+            </ListItem>
+            {currentSelectPatientGroup.length > 0 ? (
+                <ListItem key="PatientgroupSelected">
+                    <ListItemText primary="Cases Filtered" secondary={currentSelectPatientGroup.length} />
+                    <ListItemSecondaryAction>
+
+                        <IconButton onClick={() => { store.selectionStore.updateSelectedPatientGroup([]) }}>
+                            <Tooltip title="Remove">
+                                <CloseIcon />
+                            </Tooltip>
+                        </IconButton>
+
+                    </ListItemSecondaryAction>
+                </ListItem>) : <></>}
+            {currentOutputFilterSet.map((selectSet: SelectSet) => {
+                return (<ListItem key={`${selectSet.setName}selected`}>
+                    <ListItemText key={`${selectSet.setName}selected`} primary={AcronymDictionary[selectSet.setName] ? AcronymDictionary[selectSet.setName] : selectSet.setName}
+                        secondary={selectSet.setValues.sort().join(', ')} />
+                    <ListItemSecondaryAction key={`${selectSet.setName}selected`}>
+                        <IconButton key={`${selectSet.setName}selected`} onClick={() => { store.selectionStore.removeFilter(selectSet.setName) }}>
+                            <Tooltip title="Remove">
+                                <CloseIcon key={`${selectSet.setName}selected`} />
+                            </Tooltip>
+                        </IconButton>
+                    </ListItemSecondaryAction>
+                </ListItem>)
+            })}
         </List>
 
         <List dense>

--- a/frontend/src/Components/Utilities/LeftToolBox/CurrentSelected.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/CurrentSelected.tsx
@@ -11,7 +11,7 @@ import { Title, useStyles } from "../../../Presets/StyledComponents";
 const CurrentSelected: FC = () => {
     const styles = useStyles();
     const store = useContext(Store);
-    const { currentBrushedPatientGroup, currentSelectSet, currentOutputFilterSet, currentSelectPatientGroup } = store.state
+    const { currentBrushedPatientGroup, currentSelectSet } = store.state
 
     return (
         <Grid item className={styles.gridWidth}>

--- a/frontend/src/Components/Utilities/LeftToolBox/CurrentSelected.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/CurrentSelected.tsx
@@ -15,7 +15,7 @@ const CurrentSelected: FC = () => {
 
     return (
         <Grid item className={styles.gridWidth}>
-            <Container className={styles.containerWidth} style={{ height: "15vh", }}>
+            <Container className={styles.containerWidth} style={{ height: "20vh", }}>
                 <List dense>
                     <ListItem >
                         <Title>Currently Selected</Title>
@@ -47,22 +47,24 @@ const CurrentSelected: FC = () => {
 
 
                 </List>
-                <ButtonGroup style={{ textAlign: "center" }}>
+                <div style={{ textAlign: "center" }}>
                     <Button
+
                         disabled={!(currentSelectSet.length > 0 || currentBrushedPatientGroup.length > 0)}
                         variant="outlined"
-                        size="small"
+
                         className={styles.tinyFont}
                         onClick={() => { store.selectionStore.outputToFilter() }}
                     >Create Filter</Button>
-                    <Button
+                </div>
+                {/* <Button
                         disabled={!(currentOutputFilterSet.length > 0 || currentSelectPatientGroup.length > 0)}
                         variant="outlined"
                         size="small"
                         className={styles.tinyFont}
                         onClick={() => { store.selectionStore.clearAllFilter() }}
-                    >Clear Filter</Button>
-                </ButtonGroup>
+                    >Clear Filter</Button> */}
+
             </Container>
         </Grid>)
 }

--- a/frontend/src/Components/Utilities/LeftToolBox/CurrentView.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/CurrentView.tsx
@@ -7,7 +7,7 @@ import Store from "../../../Interfaces/Store"
 import { AcronymDictionary, OutcomeOptions } from "../../../Presets/DataDict"
 import { Title, useStyles } from "../../../Presets/StyledComponents"
 import Container from "@material-ui/core/Container";
-import CloseIcon from '@material-ui/icons/Close';
+
 import List from "@material-ui/core/List";
 import { Box, Chip, ListItem, ListItemSecondaryAction, ListItemText, Select, Switch, Grid, IconButton, Tooltip } from "@material-ui/core";
 import { DropdownGenerator } from "../../../HelperFunctions/DropdownGenerator"
@@ -52,7 +52,7 @@ const CurrentView: FC<Props> = ({ totalCaseNum }: Props) => {
 
     return (
         <Grid item className={styles.gridWidth} >
-            <Container className={styles.containerWidth} style={{ height: "40vh" }}>
+            <Container className={styles.containerWidth} style={{ height: "35vh" }}>
                 <List dense >
                     <ListItem style={{ textAlign: "left" }}>
                         <Title>Current View</Title>
@@ -64,17 +64,12 @@ const CurrentView: FC<Props> = ({ totalCaseNum }: Props) => {
 
                     </ListItem>
 
-                    <ListItem key="Outcomes">
-                        <ListItemText primary="Outcomes / Interventions"
-                            secondary={outcomeFilter.length > 0 ? (outcomeFilter.map((d, i) => `${AcronymDictionary[d] ? AcronymDictionary[d] : d} ${(i + 1) !== outcomeFilter.length ? "AND " : ""}`)) : "NONE"} />
-                    </ListItem>
-
-                    <ListItem key="Procedure Types">
+                    {/* <ListItem key="Procedure Types">
                         <ListItemText primary="Surgery Urgency" secondary={
                             `${surgeryUrgencySelection[0] ? "Urgent, " : ""}
                             ${surgeryUrgencySelection[1] ? "Elective, " : ""}
                             ${surgeryUrgencySelection[2] ? "Emergent" : ""}`} />
-                    </ListItem>
+                    </ListItem> */}
                     {/* TODO change this into "toggle axis" instead of "show zero" */}
                     <ListItem key="Show Zero">
                         <ListItemText primary="Show Zero Transfused"
@@ -110,26 +105,7 @@ const CurrentView: FC<Props> = ({ totalCaseNum }: Props) => {
                     <ListItem key="SurgeryList">
                         <ListItemText primary="Procedure" secondary={generateSurgery()} />
                     </ListItem>
-                    {currentSelectPatientGroup.length > 0 ? (
-                        <ListItem key="PatientgroupSelected">
-                            <ListItemText primary="Cases Filtered" secondary={currentSelectPatientGroup.length} />
-                            <ListItemSecondaryAction>
-                                <IconButton onClick={() => { store.selectionStore.updateSelectedPatientGroup([]) }}>
-                                    <CloseIcon />
-                                </IconButton>
-                            </ListItemSecondaryAction>
-                        </ListItem>) : <></>}
-                    {currentOutputFilterSet.map((selectSet: SelectSet) => {
-                        return (<ListItem key={`${selectSet.setName}selected`}>
-                            <ListItemText key={`${selectSet.setName}selected`} primary={AcronymDictionary[selectSet.setName] ? AcronymDictionary[selectSet.setName] : selectSet.setName}
-                                secondary={selectSet.setValues.sort().join(', ')} />
-                            <ListItemSecondaryAction key={`${selectSet.setName}selected`}>
-                                <IconButton key={`${selectSet.setName}selected`} onClick={() => { store.selectionStore.removeFilter(selectSet.setName) }}>
-                                    <CloseIcon key={`${selectSet.setName}selected`} />
-                                </IconButton>
-                            </ListItemSecondaryAction>
-                        </ListItem>)
-                    })}
+
                 </List>
             </Container>
         </Grid >

--- a/frontend/src/Components/Utilities/LeftToolBox/CurrentView.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/CurrentView.tsx
@@ -2,23 +2,20 @@ import { timeFormat } from "d3"
 import { observer } from "mobx-react"
 import { useContext } from "react"
 import { FC } from "react"
-import { defaultState } from "../../../Interfaces/DefaultState"
 import Store from "../../../Interfaces/Store"
-import { AcronymDictionary, OutcomeOptions } from "../../../Presets/DataDict"
+import { AcronymDictionary } from "../../../Presets/DataDict"
 import { Title, useStyles } from "../../../Presets/StyledComponents"
 import Container from "@material-ui/core/Container";
 
 import List from "@material-ui/core/List";
-import { Box, Chip, ListItem, ListItemSecondaryAction, ListItemText, Select, Switch, Grid, IconButton, Tooltip } from "@material-ui/core";
-import { DropdownGenerator } from "../../../HelperFunctions/DropdownGenerator"
-import { SelectSet } from "../../../Interfaces/Types/SelectionTypes"
+import { ListItem, ListItemSecondaryAction, ListItemText, Switch, Grid, IconButton, Tooltip } from "@material-ui/core";
+
 import ErrorIcon from '@material-ui/icons/Error';
 
 type Props = { totalCaseNum: number }
 
 const CurrentView: FC<Props> = ({ totalCaseNum }: Props) => {
-    const store = useContext(Store)
-    const { surgeryUrgencySelection, currentSelectPatientGroup, currentOutputFilterSet, outcomeFilter } = store.state;
+    const store = useContext(Store);
     const styles = useStyles();
 
 
@@ -64,12 +61,7 @@ const CurrentView: FC<Props> = ({ totalCaseNum }: Props) => {
 
                     </ListItem>
 
-                    {/* <ListItem key="Procedure Types">
-                        <ListItemText primary="Surgery Urgency" secondary={
-                            `${surgeryUrgencySelection[0] ? "Urgent, " : ""}
-                            ${surgeryUrgencySelection[1] ? "Elective, " : ""}
-                            ${surgeryUrgencySelection[2] ? "Emergent" : ""}`} />
-                    </ListItem> */}
+
                     {/* TODO change this into "toggle axis" instead of "show zero" */}
                     <ListItem key="Show Zero">
                         <ListItemText primary="Show Zero Transfused"

--- a/frontend/src/Components/Utilities/TopMenu/AddModeTopMenu.tsx
+++ b/frontend/src/Components/Utilities/TopMenu/AddModeTopMenu.tsx
@@ -171,6 +171,7 @@ const AddModeTopMenu: FC<Props> = ({ addingChartType }: Props) => {
         <div className={styles.centerAlignment}>
             <ButtonGroup>
                 <Button
+                    disableElevation
                     variant="contained"
                     color="primary"
                     disabled={!checkValidInput()}
@@ -178,6 +179,7 @@ const AddModeTopMenu: FC<Props> = ({ addingChartType }: Props) => {
                     Confirm
                 </Button>
                 <Button
+                    disableElevation
                     variant="contained"
                     onClick={cancelChartAddHandler} >
                     Cancel

--- a/frontend/src/Components/Utilities/TopMenu/RegularModeMenu.tsx
+++ b/frontend/src/Components/Utilities/TopMenu/RegularModeMenu.tsx
@@ -48,31 +48,35 @@ const RegularModeMenu: FC = () => {
 
 
         <Toolbar className={styles.toolbarPaddingControl}>
-            <IconButton
-                edge="start"
-                onClick={handleDrawerOpen}
-                color="inherit"
-                aria-label="open drawer"
-            >
-                <MenuIcon />
-            </IconButton>
+            <Tooltip title={<div>  <p className={styles.tooltipFont}>Filter</p></div>}>
+
+                <IconButton
+                    edge="start"
+                    onClick={handleDrawerOpen}
+                    color="inherit"
+                    aria-label="open drawer"
+                >
+                    <MenuIcon />
+                </IconButton>
+            </Tooltip>
 
 
-            <div className={useStyles().centerAlignment}>
-                <Button variant="contained" disableElevation onClick={handleClick} aria-controls="simple-menu" aria-haspopup="true" >Add</Button>
-                <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={() => handleClose()}>
-                    <MenuItem onClick={() => handleClose(1)}>Dumbbell Chart</MenuItem>
-                    <MenuItem onClick={() => handleClose(2)}>Scatter Plot</MenuItem>
-                    <MenuItem onClick={() => handleClose(3)}>Heat Map</MenuItem>
-                    <MenuItem onClick={() => handleClose(0)}>Cost and Saving Chart</MenuItem>
-                </Menu>
-            </div>
 
 
             <a href="https://healthcare.utah.edu" target="_blank">
                 <img
                     className={styles.img}
                     src="https://raw.githubusercontent.com/visdesignlab/Sanguine/main/images/u-of-u-health-social.png" />
+            </a>
+            <a href="https://arup.utah.edu" target="_blank">
+                <img
+                    className={styles.img}
+                    src="https://raw.githubusercontent.com/visdesignlab/Sanguine/main/images/ARUP-logo.png" />
+            </a>
+            <a href="https://vdl.sci.utah.edu" target="_blank">
+                <img
+                    className={styles.img}
+                    src="https://raw.githubusercontent.com/visdesignlab/Sanguine/main/images/vdl.png" />
             </a>
 
             <Typography className={styles.title} variant="h6" noWrap>
@@ -86,46 +90,56 @@ const RegularModeMenu: FC = () => {
                  // onClick={() => { store!.previewMode = true }} 
             </div> */}
 
-           
-            <a href="https://arup.utah.edu" target="_blank">
-                <img
-                    className={styles.img}
-                    src="https://raw.githubusercontent.com/visdesignlab/Sanguine/main/images/ARUP-logo.png" />
-            </a>
-            <a href="https://vdl.sci.utah.edu" target="_blank">
-                <img
-                    className={styles.img}
-                    src="https://raw.githubusercontent.com/visdesignlab/Sanguine/main/images/vdl.png" />
-            </a>
 
+
+
+            <div className={useStyles().centerAlignment}>
+                <Button variant="contained" disableElevation onClick={handleClick} aria-controls="simple-menu" aria-haspopup="true" >Add</Button>
+                <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={() => handleClose()}>
+                    <MenuItem onClick={() => handleClose(1)}>Dumbbell Chart</MenuItem>
+                    <MenuItem onClick={() => handleClose(2)}>Scatter Plot</MenuItem>
+                    <MenuItem onClick={() => handleClose(3)}>Heat Map</MenuItem>
+                    <MenuItem onClick={() => handleClose(0)}>Cost and Saving Chart</MenuItem>
+                </Menu>
+            </div>
 
             <StateManagementSuite />
 
-            <Tooltip title={<div>  <p className={styles.tooltipFont}>Clear All</p></div>}>
-                <IconButton disabled={store.isAtRoot} onClick={() => { store.configStore.resetAll() }}>
+
+            <IconButton disabled={store.isAtRoot} onClick={() => { store.configStore.resetAll() }}>
+                <Tooltip title={<div>  <p className={styles.tooltipFont}>Clear All</p></div>}>
                     <ClearAllIcon />
-                </IconButton>
-            </Tooltip>
+                </Tooltip>
+            </IconButton>
+
 
             <UndoRedoButtons />
 
             <IconButton onClick={() => { store.configStore.largeFont = !store.configStore.largeFont }} >
-                <FormatSizeIcon className={store.configStore.largeFont ? `` : styles.manualDisable} />
+                <Tooltip title={<div>  <p className={styles.tooltipFont}>Change Font Size</p></div>}>
+                    <FormatSizeIcon className={store.configStore.largeFont ? `` : styles.manualDisable} />
+                </Tooltip>
             </IconButton>
 
             <IconButton onClick={() => { store.configStore.openAboutDialog = true; }}>
-                <InfoOutlinedIcon />
+                <Tooltip title={<div>  <p className={styles.tooltipFont}>About</p></div>}>
+                    <InfoOutlinedIcon />
+                </Tooltip>
             </IconButton>
             <InfoDialog />
 
             <a href="https://github.com/visdesignlab/Sanguine/issues" target="_blank" rel="noopener noreferrer">
                 <IconButton size="small">
-                    <BugReportOutlinedIcon />
+                    <Tooltip title={<div>  <p className={styles.tooltipFont}>Report a Bug</p></div>}>
+                        <BugReportOutlinedIcon />
+                    </Tooltip>
                 </IconButton>
             </a>
 
             <IconButton onClick={() => { logoutHandler() }} >
-                <ExitToAppIcon />
+                <Tooltip title={<div>  <p className={styles.tooltipFont}>Exit</p></div>}>
+                    <ExitToAppIcon />
+                </Tooltip>
             </IconButton>
             <FilterBoard />
         </Toolbar>

--- a/frontend/src/Components/Utilities/TopMenu/RegularModeMenu.tsx
+++ b/frontend/src/Components/Utilities/TopMenu/RegularModeMenu.tsx
@@ -94,7 +94,7 @@ const RegularModeMenu: FC = () => {
 
 
             <div className={useStyles().centerAlignment}>
-                <Button variant="contained" disableElevation onClick={handleClick} aria-controls="simple-menu" aria-haspopup="true" >Add</Button>
+                <Button color="primary" variant="contained" disableElevation onClick={handleClick} aria-controls="simple-menu" aria-haspopup="true" >Add</Button>
                 <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={() => handleClose()}>
                     <MenuItem onClick={() => handleClose(1)}>Dumbbell Chart</MenuItem>
                     <MenuItem onClick={() => handleClose(2)}>Scatter Plot</MenuItem>

--- a/frontend/src/Components/Utilities/TopMenu/StateManagementSuite.tsx
+++ b/frontend/src/Components/Utilities/TopMenu/StateManagementSuite.tsx
@@ -10,6 +10,7 @@ import SaveStateModal from "../../Modals/SaveStateModal";
 const StateManagementSuite: FC = () => {
     const styles = useStyles();
     const store = useContext(Store);
+
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
 

--- a/frontend/src/Components/Utilities/TopMenu/UndoRedoButtons.tsx
+++ b/frontend/src/Components/Utilities/TopMenu/UndoRedoButtons.tsx
@@ -4,19 +4,28 @@ import { FC, useContext } from "react";
 import RedoIcon from '@material-ui/icons/Redo';
 import UndoIcon from '@material-ui/icons/Undo';
 import Store from "../../../Interfaces/Store";
-import { IconButton } from "@material-ui/core";
+import { IconButton, Tooltip } from "@material-ui/core";
+import { useStyles } from "../../../Presets/StyledComponents";
 
 const UndoRedoButtons: FC = () => {
     const store = useContext(Store);
+    const styles = useStyles();
 
-    return <ButtonGroup>
+    return <ButtonGroup size="small">
+
         <IconButton disabled={store.isAtRoot} onClick={() => { store.provenance.undo() }}>
-            <UndoIcon />
+            <Tooltip title={<div>  <p className={styles.tooltipFont}>Undo</p></div>}>
+                <UndoIcon />
+            </Tooltip>
         </IconButton>
+
 
         <IconButton disabled={store.isAtLatest} onClick={() => { store.provenance.redo() }}>
-            <RedoIcon />
+            <Tooltip title={<div>  <p className={styles.tooltipFont}>Redo</p></div>}>
+                <RedoIcon />
+            </Tooltip>
         </IconButton>
+
     </ButtonGroup>
 
 }

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -9,14 +9,17 @@ import './App.css'
 import LayoutGenerator from "./Components/LayoutGenerator"
 import { DataContext } from "./App"
 import Grid from "@material-ui/core/Grid"
-import { Box, Divider } from "@material-ui/core"
+import { Box, Divider, Snackbar } from "@material-ui/core"
 import DetailView from "./Components/Utilities/DetailView/DetailView"
-
+import { Alert } from "@material-ui/lab";
+import Store from "./Interfaces/Store"
+import { SnackBarCloseTime } from "./Presets/Constants"
 
 
 const Dashboard: FC = () => {
 
-    const hemoData = useContext(DataContext)
+    const hemoData = useContext(DataContext);
+    const store = useContext(Store);
     return (
         <div>
             <Box id="Top-Bar">
@@ -42,6 +45,11 @@ const Dashboard: FC = () => {
                     <DataRetrieval />
                 </> : <></>}
 
+            <Snackbar open={store.configStore.openNoteSaveSuccessMessage} autoHideDuration={SnackBarCloseTime} onClose={() => { store.configStore.openNoteSaveSuccessMessage = false }}>
+                <Alert onClose={() => { store.configStore.openNoteSaveSuccessMessage = false }} severity="success">
+                    Note saved locally!
+                </Alert>
+            </Snackbar>
         </div>
     )
 }

--- a/frontend/src/HelperFunctions/ExtraPairDataGenerator.ts
+++ b/frontend/src/HelperFunctions/ExtraPairDataGenerator.ts
@@ -12,6 +12,7 @@ export const generateExtrapairPlotData = (aggregatedBy: string, hemoglobinDataSe
             let medianData = {} as any;
             let kdeMax_temp: any = 0
             switch (variable) {
+
                 case "TOTAL_TRANS":
                     //let newDataBar = {} as any;
                     data.forEach((dataPoint: BasicAggregatedDatePoint) => {

--- a/frontend/src/Interfaces/Actions/ProjectConfigActions.ts
+++ b/frontend/src/Interfaces/Actions/ProjectConfigActions.ts
@@ -47,3 +47,13 @@ export const changeTestValueFilter = createAction<ApplicationState, [string, num
 export const resetTestValueFilter = createAction<ApplicationState, [], ActionEvents>((state) => {
     state.testValueFilter = defaultState.testValueFilter;
 }).setLabel("resetTestValueFilter");
+
+export const clearAllFilter = createAction<ApplicationState, [], ActionEvents>((state) => {
+    state.currentSelectPatientGroup = [];
+    state.currentOutputFilterSet = [];
+    state.rawDateRange = defaultState.rawDateRange;
+    state.outcomeFilter = [];
+    state.testValueFilter = defaultState.testValueFilter;
+    state.bloodComponentFilter = defaultState.bloodComponentFilter;
+    state.surgeryUrgencySelection = defaultState.surgeryUrgencySelection
+}).setLabel("clearAllFilter");

--- a/frontend/src/Interfaces/Actions/SelectionActions.ts
+++ b/frontend/src/Interfaces/Actions/SelectionActions.ts
@@ -54,10 +54,10 @@ export const clearSet = createAction<ApplicationState, [string], ActionEvents>((
     state.currentSelectSet = state.currentSelectSet.filter(d => d.setName !== selectNameToRemove)
 }).setLabel("selectSetToRemove")
 
-export const clearAllFilter = createAction<ApplicationState, [], ActionEvents>((state) => {
+export const clearSelectionFilter = createAction<ApplicationState, [], ActionEvents>((state) => {
     state.currentSelectPatientGroup = [];
     state.currentOutputFilterSet = []
-}).setLabel("clearAllFilter");
+}).setLabel("clearSelectionFilter");
 
 export const outputToFilter = createAction<ApplicationState, [], ActionEvents>((state) => {
     state.currentOutputFilterSet = state.currentSelectSet;

--- a/frontend/src/Interfaces/Actions/SelectionActions.ts
+++ b/frontend/src/Interfaces/Actions/SelectionActions.ts
@@ -1,4 +1,5 @@
 import { createAction } from "@visdesignlab/trrack";
+import { defaultState } from "../DefaultState";
 import { SingleCasePoint } from "../Types/DataTypes";
 import { ActionEvents } from "../Types/EventTypes";
 import { ApplicationState } from "../Types/StateTypes";
@@ -69,3 +70,4 @@ export const outputToFilter = createAction<ApplicationState, [], ActionEvents>((
 export const removeFilter = createAction<ApplicationState, [string], ActionEvents>((state, filterToRemove) => {
     state.currentOutputFilterSet = state.currentOutputFilterSet.filter(d => d.setName !== filterToRemove)
 }).setLabel("clearFilter");
+

--- a/frontend/src/Interfaces/ProjectConfigStore.ts
+++ b/frontend/src/Interfaces/ProjectConfigStore.ts
@@ -17,6 +17,7 @@ export class ProjectConfigStore {
     openStateAccessControl: boolean;
     openAboutDialog: boolean;
     openDrawer: boolean;
+    openNoteSaveSuccessMessage: boolean;
     largeFont: boolean;
     savedState: string[];
     filterRange: any;
@@ -31,6 +32,7 @@ export class ProjectConfigStore {
         this.openSaveStateDialog = false;
         this.openManageStateDialog = false;
         this.openShareUIDDialog = false;
+        this.openNoteSaveSuccessMessage = false;
         this.openDrawer = false;
         this.openCostInputModal = false;
         this.openStateAccessControl = false;

--- a/frontend/src/Interfaces/ProjectConfigStore.ts
+++ b/frontend/src/Interfaces/ProjectConfigStore.ts
@@ -1,6 +1,6 @@
 import { makeAutoObservable } from "mobx";
 import { BloodComponentOptions } from "../Presets/DataDict";
-import { changeBloodFilter, changeCostConfig, changeOutcomeFilter, changeSurgeryUrgencySelection, changeTestValueFilter, dateRangeChange, loadPreset, resetBloodFilter, resetTestValueFilter, toggleShowZero } from "./Actions/ProjectConfigActions";
+import { changeBloodFilter, changeCostConfig, changeOutcomeFilter, changeSurgeryUrgencySelection, changeTestValueFilter, clearAllFilter, dateRangeChange, loadPreset, resetBloodFilter, resetTestValueFilter, toggleShowZero } from "./Actions/ProjectConfigActions";
 import { RootStore } from "./Store";
 import { LayoutElement } from "./Types/LayoutTypes";
 
@@ -129,5 +129,8 @@ export class ProjectConfigStore {
     }
     resetAll() {
         this.provenance.reset();
+    }
+    clearAllFilter() {
+        this.provenance.apply(clearAllFilter())
     }
 }

--- a/frontend/src/Interfaces/SelectionStore.ts
+++ b/frontend/src/Interfaces/SelectionStore.ts
@@ -1,5 +1,5 @@
 import { makeAutoObservable } from "mobx";
-import { clearAllFilter, clearSet, outputToFilter, removeFilter, selectSet, setCurrentSelectPatient, updateBrushPatient, updateProcedureSelection, updateSelectedPatientGroup } from "./Actions/SelectionActions";
+import { clearSelectionFilter, clearSet, outputToFilter, removeFilter, selectSet, setCurrentSelectPatient, updateBrushPatient, updateProcedureSelection, updateSelectedPatientGroup } from "./Actions/SelectionActions";
 import { RootStore } from "./Store";
 import { SingleCasePoint } from "./Types/DataTypes";
 
@@ -31,8 +31,8 @@ export class SelectionStore {
         this.provenance.apply(setCurrentSelectPatient(newCase))
     }
 
-    clearAllFilter() {
-        this.provenance.apply(clearAllFilter())
+    clearSelectionFilter() {
+        this.provenance.apply(clearSelectionFilter())
     }
 
     outputToFilter() {

--- a/frontend/src/Presets/StyledComponents.ts
+++ b/frontend/src/Presets/StyledComponents.ts
@@ -102,6 +102,8 @@ export const useStyles = makeStyles((theme: Theme) =>
         },
         containerWidth: {
             width: "100%",
+            paddingLeft: "5px",
+            paddingRight: "5px",
             maxWidth: "none",
             overflow: "hidden",
             height: "100%",

--- a/frontend/src/Presets/StyledSVGComponents.ts
+++ b/frontend/src/Presets/StyledSVGComponents.ts
@@ -1,6 +1,10 @@
 import styled from "styled-components";
 import { Offset } from "../Interfaces/Types/OffsetType";
-import { Basic_Gray, highlight_orange, postop_color, preop_color } from "./Constants";
+import { Basic_Gray, highlight_orange, largeFontSize, postop_color, preop_color, regularFontSize } from "./Constants";
+
+export interface BiggerFontProps {
+    biggerFont: boolean
+}
 
 export const ChartSVG = styled.svg`
   height: calc(100% - 100px);
@@ -38,7 +42,7 @@ export const HeatMapRect = styled(`rect`)`
 `
 interface HeatMapDivideProp {
     currentOffset: Offset;
-    dimensionHeight: number
+    dimensionHeight: number;
 }
 
 export const HeatMapDividerLine = styled(`line`) <HeatMapDivideProp>`
@@ -81,11 +85,12 @@ export const DumbbellLine = styled(`line`) < AverageLineProps>`
     stroke-width:3px
     `
 
-export const AxisText = styled.text`
+export const AxisText = styled.text<BiggerFontProps>`
     fill:white;
     alignment-baseline: hanging;
     text-anchor: middle;
     y:0;
+    font-size:${props => props.biggerFont ? `${largeFontSize}px` : `${regularFontSize}px`};
 `
 
 export const CustomAxisLine = styled(`line`)`


### PR DESCRIPTION
- [x] Add tooltips for all icons of top menu.
- [x] Relocate clear filter to gather all filter under the same drawer.
- [x] font change button should apply to all chart texts/axis/label
- [x] crowding issue with procedure list
- [x] Save annotation automatically when out of focus? (experiment)
- [x] add an "X" or something similar to make the remove of extra pair plots more apparent. 
- [x] padding for legend. alignment issue?
- [x] move all buttons to the right side and have the logos on the left side. 
- [x] Add a remove all filter button on top of filter drawer.
- [x] remove text button elevation in add mode. 
- [ ] <strike>Make scrollable list more apparent</strike> I don't know how.
- [ ] <strike>padding for heat map row green/blue rectangles</strike> I don't like the white space. Doesn't look very good. 
- [ ] Address when testing PR: #174 
