### PR TITLE
resolves #158

### DIFF
--- a/frontend/src/Components/Charts/ChartAccessories/AnnotationForm.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/AnnotationForm.tsx
@@ -31,7 +31,9 @@ const AnnotationForm: FC<Props> = ({ annotationText, chartI }: Props) => {
             onBlur={() => {
                 if (formInput !== annotationText) {
                     store.chartStore.changeNotation(chartI, formInput);
-                    store.configStore.openNoteSaveSuccessMessage = true;
+                    store.configStore.openSnackBar = true;
+                    store.configStore.snackBarMessage = "Note Saved Locally."
+                    store.configStore.snackBarIsError = false;
                 }
             }}
             onChange={(e) => { setFormInput(e.target.value) }}

--- a/frontend/src/Components/Modals/ManageStateDialog.tsx
+++ b/frontend/src/Components/Modals/ManageStateDialog.tsx
@@ -62,7 +62,7 @@ const ManageStateDialog: FC = () => {
 
     // const changeStateName = ()
 
-    return (<div>
+    return (<div style={{ minWidth: "50vh" }}>
         <Dialog open={store.configStore.openManageStateDialog}>
             <DialogTitle>Manage Saved States</DialogTitle>
             <DialogContent style={{ maxHeight: "300px" }}>

--- a/frontend/src/Components/Modals/ManageStateDialog.tsx
+++ b/frontend/src/Components/Modals/ManageStateDialog.tsx
@@ -69,7 +69,7 @@ const ManageStateDialog: FC = () => {
                 <List>{
                     store.configStore.savedState.map((d) => {
                         return (<ListItem>
-                            <ListItemText primary={d} />
+                            <ListItemText primary={d} style={{ maxWidth: "375px" }} />
                             <ListItemSecondaryAction>
                                 <IconButton onClick={() => {
                                     store.configStore.openManageStateDialog = false;
@@ -80,7 +80,6 @@ const ManageStateDialog: FC = () => {
                                         <EditIcon />
                                     </Tooltip>
                                 </IconButton>
-
                                 <IconButton onClick={() => { changeStateAccess(d) }}>
                                     <Tooltip title={<div>  <p className={styles.tooltipFont}>Manage Sharing</p></div>}>
                                         <ShareIcon />

--- a/frontend/src/Components/Modals/ManageStateDialog.tsx
+++ b/frontend/src/Components/Modals/ManageStateDialog.tsx
@@ -62,10 +62,10 @@ const ManageStateDialog: FC = () => {
 
     // const changeStateName = ()
 
-    return (<div style={{ minWidth: "50vh" }}>
-        <Dialog open={store.configStore.openManageStateDialog}>
+    return (<div >
+        <Dialog open={store.configStore.openManageStateDialog} >
             <DialogTitle>Manage Saved States</DialogTitle>
-            <DialogContent style={{ maxHeight: "300px" }}>
+            <DialogContent style={{ maxHeight: "300px", minWidth: "50vh" }}>
                 <List>{
                     store.configStore.savedState.map((d) => {
                         return (<ListItem>

--- a/frontend/src/Components/Modals/ManageStateDialog.tsx
+++ b/frontend/src/Components/Modals/ManageStateDialog.tsx
@@ -63,9 +63,9 @@ const ManageStateDialog: FC = () => {
     // const changeStateName = ()
 
     return (<div >
-        <Dialog open={store.configStore.openManageStateDialog} >
+        <Dialog open={store.configStore.openManageStateDialog} fullWidth>
             <DialogTitle>Manage Saved States</DialogTitle>
-            <DialogContent style={{ maxHeight: "300px", minWidth: "50vh" }}>
+            <DialogContent >
                 <List>{
                     store.configStore.savedState.map((d) => {
                         return (<ListItem>

--- a/frontend/src/Components/Modals/ManageStateDialog.tsx
+++ b/frontend/src/Components/Modals/ManageStateDialog.tsx
@@ -1,20 +1,18 @@
-import { Button, DialogActions, DialogContent, IconButton, List, ListItem, ListItemSecondaryAction, ListItemText, Snackbar } from "@material-ui/core";
+import { Button, DialogActions, DialogContent, IconButton, List, ListItem, ListItemSecondaryAction, ListItemText, Tooltip } from "@material-ui/core";
 import { Dialog, DialogTitle } from "@material-ui/core";
 import { FC, useContext, useState } from "react";
 import Store from "../../Interfaces/Store";
 import DeleteIcon from '@material-ui/icons/Delete';
+import ShareIcon from '@material-ui/icons/Share';
 import EditIcon from '@material-ui/icons/Edit';
 import { simulateAPIClick } from "../../Interfaces/UserManagement";
-import { Alert } from "@material-ui/lab";
 import { observer } from "mobx-react";
-import { SnackBarCloseTime } from "../../Presets/Constants";
 import StateAccessControl from "./StateAccessControl";
+import { useStyles } from "../../Presets/StyledComponents";
 
 const ManageStateDialog: FC = () => {
     const store = useContext(Store);
-    const [errorMessage, setErrorMessage] = useState("")
-    const [openErrorMessage, setOpenError] = useState(false);
-    const [openSuccess, setOpenSuccess] = useState(false);
+    const styles = useStyles();
     const [stateNameToChange, setStateNameToChange] = useState("")
 
 
@@ -33,19 +31,25 @@ const ManageStateDialog: FC = () => {
             body: JSON.stringify({ name: stateName })
         }).then(response => {
             if (response.status === 200) {
+                if (store.configStore.loadedStateName === stateName) {
+                    store.configStore.loadedStateName = "";
+                }
                 store.configStore.savedState = store.configStore.savedState.filter(d => d !== stateName)
-                setOpenSuccess(true);
-                setErrorMessage("")
+                store.configStore.snackBarIsError = false;
+                store.configStore.snackBarMessage = "Deletion succeed."
+                store.configStore.openSnackBar = true;
             } else {
                 response.text().then(error => {
-                    setErrorMessage(response.statusText);
-                    setOpenError(true)
+                    store.configStore.snackBarMessage = `An error occurred: ${response.statusText}`;
+                    store.configStore.snackBarIsError = true;
+                    store.configStore.openSnackBar = true;
                     console.error('There has been a problem with your fetch operation:', response.statusText);
                 })
             }
         }).catch(error => {
-            setErrorMessage(error)
-            setOpenError(true)
+            store.configStore.snackBarMessage = `An error occurred: ${error}`;
+            store.configStore.snackBarIsError = true;
+            store.configStore.openSnackBar = true;
             console.error('There has been a problem with your fetch operation:', error);
         })
     }
@@ -56,6 +60,8 @@ const ManageStateDialog: FC = () => {
         setStateNameToChange(stateName);
     }
 
+    // const changeStateName = ()
+
     return (<div>
         <Dialog open={store.configStore.openManageStateDialog}>
             <DialogTitle>Manage Saved States</DialogTitle>
@@ -65,12 +71,27 @@ const ManageStateDialog: FC = () => {
                         return (<ListItem>
                             <ListItemText primary={d} />
                             <ListItemSecondaryAction>
-                                <IconButton onClick={() => { removeState(d) }}>
-                                    <DeleteIcon />
+                                <IconButton onClick={() => {
+                                    store.configStore.openManageStateDialog = false;
+                                    store.configStore.stateToUpdate = d;
+                                    store.configStore.openSaveStateDialog = true;
+                                }}>
+                                    <Tooltip title={<div>  <p className={styles.tooltipFont}>Edit State</p></div>}>
+                                        <EditIcon />
+                                    </Tooltip>
                                 </IconButton>
+
                                 <IconButton onClick={() => { changeStateAccess(d) }}>
-                                    <EditIcon />
+                                    <Tooltip title={<div>  <p className={styles.tooltipFont}>Manage Sharing</p></div>}>
+                                        <ShareIcon />
+                                    </Tooltip>
                                 </IconButton>
+                                <IconButton onClick={() => { removeState(d) }}>
+                                    <Tooltip title={<div>  <p className={styles.tooltipFont}>Delete State</p></div>}>
+                                        <DeleteIcon />
+                                    </Tooltip>
+                                </IconButton>
+
                             </ListItemSecondaryAction>
                         </ListItem>)
                     })}
@@ -83,16 +104,6 @@ const ManageStateDialog: FC = () => {
             </DialogActions>
         </Dialog>
         <StateAccessControl stateName={stateNameToChange} />
-        <Snackbar open={openErrorMessage} autoHideDuration={SnackBarCloseTime} onClose={() => { setOpenError(false) }}>
-            <Alert onClose={() => { setOpenError(false); setErrorMessage("") }} severity="error">
-                An error occured: {errorMessage}
-            </Alert>
-        </Snackbar>
-        <Snackbar open={openSuccess} autoHideDuration={SnackBarCloseTime} onClose={() => { setOpenSuccess(false) }}>
-            <Alert onClose={() => { setOpenSuccess(false) }} severity="success">
-                Deletion succeed.
-            </Alert>
-        </Snackbar>
     </div>)
 }
 

--- a/frontend/src/Components/Modals/SaveStateModal.tsx
+++ b/frontend/src/Components/Modals/SaveStateModal.tsx
@@ -32,6 +32,7 @@ const SaveStateModal: FC = () => {
 
                 if (response.status === 200) {
                     store.configStore.stateToUpdate = "";
+                    store.configStore.stateToUpdate = stateName;
                     onSuccess();
                 } else {
                     response.text().then(error => {
@@ -61,6 +62,7 @@ const SaveStateModal: FC = () => {
                 body: `csrfmiddlewaretoken=${csrftoken}&name=${stateName}&definition=${store.provenance.exportState(false)}&public=${publicAccess.toString()}`
             }).then(response => {
                 if (response.status === 200) {
+                    store.configStore.stateToUpdate = stateName;
                     onSuccess();
                 } else {
                     response.text().then(error => {

--- a/frontend/src/Components/Modals/SaveStateModal.tsx
+++ b/frontend/src/Components/Modals/SaveStateModal.tsx
@@ -12,7 +12,11 @@ const SaveStateModal: FC = () => {
 
     useEffect(() => {
         setStateName(store.configStore.stateToUpdate);
-    }, [store.configStore.stateToUpdate])
+    }, [store.configStore.stateToUpdate]);
+
+    function capitalizeFirstLetter(string) {
+        return string.charAt(0).toUpperCase() + string.slice(1);
+    };
 
     const saveNewState = () => {
         const csrftoken = simulateAPIClick()
@@ -27,7 +31,7 @@ const SaveStateModal: FC = () => {
                     "Access-Control-Allow-Origin": 'https://bloodvis.chpc.utah.edu',
                     "Access-Control-Allow-Credentials": "true",
                 },
-                body: JSON.stringify({ old_name: store.configStore.stateToUpdate, new_name: stateName, new_definition: store.provenance.exportState(false), new_public: publicAccess })
+                body: JSON.stringify({ old_name: store.configStore.stateToUpdate, new_name: stateName, new_definition: store.provenance.exportState(false), new_public: capitalizeFirstLetter(publicAccess.toString()) })
             }).then(response => {
 
                 if (response.status === 200) {

--- a/frontend/src/Components/Modals/SaveStateModal.tsx
+++ b/frontend/src/Components/Modals/SaveStateModal.tsx
@@ -36,7 +36,7 @@ const SaveStateModal: FC = () => {
 
                 if (response.status === 200) {
                     store.configStore.stateToUpdate = "";
-                    store.configStore.stateToUpdate = stateName;
+                    store.configStore.loadedStateName = stateName;
                     onSuccess();
                 } else {
                     response.text().then(error => {
@@ -66,7 +66,7 @@ const SaveStateModal: FC = () => {
                 body: `csrfmiddlewaretoken=${csrftoken}&name=${stateName}&definition=${store.provenance.exportState(false)}&public=${publicAccess.toString()}`
             }).then(response => {
                 if (response.status === 200) {
-                    store.configStore.stateToUpdate = stateName;
+                    store.configStore.loadedStateName = stateName;
                     onSuccess();
                 } else {
                     response.text().then(error => {

--- a/frontend/src/Components/Modals/SaveStateModal.tsx
+++ b/frontend/src/Components/Modals/SaveStateModal.tsx
@@ -14,7 +14,7 @@ const SaveStateModal: FC = () => {
         setStateName(store.configStore.stateToUpdate);
     }, [store.configStore.stateToUpdate]);
 
-    function capitalizeFirstLetter(string) {
+    const capitalizeFirstLetter = (string: string) => {
         return string.charAt(0).toUpperCase() + string.slice(1);
     };
 

--- a/frontend/src/Components/Modals/StateAccessControl.tsx
+++ b/frontend/src/Components/Modals/StateAccessControl.tsx
@@ -1,11 +1,9 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControlLabel, FormGroup, IconButton, List, ListItem, ListItemSecondaryAction, ListItemText, Radio, RadioGroup, Snackbar, TextField } from "@material-ui/core";
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControlLabel, IconButton, List, ListItem, ListItemSecondaryAction, ListItemText, Radio, RadioGroup, } from "@material-ui/core";
 import AddIcon from '@material-ui/icons/Add';
-import { Alert } from "@material-ui/lab";
 import { observer } from "mobx-react";
 import { FC, useContext, useEffect, useState } from "react";
 import Store from "../../Interfaces/Store";
 import { simulateAPIClick } from "../../Interfaces/UserManagement";
-import { SnackBarCloseTime } from "../../Presets/Constants";
 import UIDInputModal from "./UIDInputModal";
 
 type Props = {
@@ -16,9 +14,6 @@ const StateAccessControl: FC<Props> = ({ stateName }: Props) => {
 
     const [uIDShared, updateUIDShared] = useState<string[]>([]);
     const [accessArray, updateAccessArray] = useState<string[]>([])
-    const [errorMessage, setErrorMessage] = useState("");
-    const [openErrorMessage, setOpenErrorMessage] = useState(false);
-    const [openSuccessMessage, setOpenSuccess] = useState(false)
 
     const makeStateAccessRequest = () => {
         if (stateName) {
@@ -35,9 +30,8 @@ const StateAccessControl: FC<Props> = ({ stateName }: Props) => {
                     })
                     updateUIDShared(uID);
                     updateAccessArray(access);
-
-
-                });
+                })
+                .catch(error => { console.log(error) });
         }
     }
 
@@ -61,22 +55,28 @@ const StateAccessControl: FC<Props> = ({ stateName }: Props) => {
         })
             .then(response => {
                 if (response.status === 200) {
-                    setOpenSuccess(true)
-                    setErrorMessage("");
-                    setOpenErrorMessage(false);
+
+                    store.configStore.snackBarIsError = false;
+                    store.configStore.snackBarMessage = "Change succeed.";
+                    store.configStore.openSnackBar = true;
                     // let newAccessArray = accessArray;
                     // newAccessArray[indexInArray] = newAccess
                     // updateAccessArray(newAccessArray)
                     makeStateAccessRequest()
                 } else {
                     response.text().then(error => {
-                        setErrorMessage(response.statusText);
-                        setOpenErrorMessage(true)
+
+                        store.configStore.snackBarIsError = true;
+                        store.configStore.snackBarMessage = `An error occurred: ${response.statusText}`;
+                        store.configStore.openSnackBar = true;
+
                         console.error('There has been a problem with your fetch operation:', response.statusText);
                     })
                 }
             }).catch(error => {
-                setErrorMessage(error)
+                store.configStore.snackBarIsError = true;
+                store.configStore.snackBarMessage = `An error occurred: ${error}`;
+                store.configStore.openSnackBar = true;
                 console.error('There has been a problem with your fetch operation:', error);
             })
     }
@@ -133,16 +133,7 @@ const StateAccessControl: FC<Props> = ({ stateName }: Props) => {
                 </Button>
             </DialogActions>
         </Dialog>
-        <Snackbar open={openErrorMessage} autoHideDuration={SnackBarCloseTime} onClose={() => { setOpenErrorMessage(false) }}>
-            <Alert onClose={() => { setOpenErrorMessage(false); setErrorMessage("") }} severity="error">
-                An error occured: {errorMessage}
-            </Alert>
-        </Snackbar>
-        <Snackbar open={openSuccessMessage} autoHideDuration={SnackBarCloseTime} onClose={() => { setOpenSuccess(false) }}>
-            <Alert onClose={() => { setOpenSuccess(false) }} severity="success">
-                Change succeed.
-            </Alert>
-        </Snackbar>
+
         <UIDInputModal stateName={stateName} />
     </div>)
 }

--- a/frontend/src/Components/Modals/UIDInputModal.tsx
+++ b/frontend/src/Components/Modals/UIDInputModal.tsx
@@ -1,10 +1,8 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, FormControlLabel, FormGroup, InputAdornment, Snackbar, Switch, TextField } from "@material-ui/core";
-import { Alert } from "@material-ui/lab";
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, FormControlLabel, FormGroup, InputAdornment, Switch, TextField } from "@material-ui/core";
 import { observer } from "mobx-react";
 import { FC, useContext, useState } from "react";
 import Store from "../../Interfaces/Store";
 import { simulateAPIClick } from "../../Interfaces/UserManagement";
-import { SnackBarCloseTime } from "../../Presets/Constants";
 
 type Props = {
     stateName: string;
@@ -13,9 +11,6 @@ const UIDInputModal: FC<Props> = ({ stateName }: Props) => {
     const store = useContext(Store);
     const [uIDInput, setUIDInput] = useState("");
     const [writeAccess, setWriteAccess] = useState(false);
-    const [errorMessage, setErrorMessage] = useState("");
-    const [openErrorMessage, setOpenErrorMessage] = useState(false);
-    const [openSuccessMessage, setOpenSuccess] = useState(false)
 
     const shareState = () => {
         const csrftoken = simulateAPIClick()
@@ -33,21 +28,27 @@ const UIDInputModal: FC<Props> = ({ stateName }: Props) => {
         })
             .then(response => {
                 if (response.status === 200) {
-                    setOpenSuccess(true)
+
+                    store.configStore.snackBarIsError = false;
+                    store.configStore.snackBarMessage = "State shared successfully!";
+                    store.configStore.openSnackBar = true;
+
+
                     setUIDInput("");
                     setWriteAccess(false);
-                    setErrorMessage("");
-                    setOpenErrorMessage(false);
                     store.configStore.openShareUIDDialog = false;
                 } else {
                     response.text().then(error => {
-                        setErrorMessage(response.statusText);
-                        setOpenErrorMessage(true)
+                        store.configStore.snackBarIsError = true;
+                        store.configStore.snackBarMessage = `An error occurred: ${response.statusText}`
+                        store.configStore.openSnackBar = true;
                         console.error('There has been a problem with your fetch operation:', response.statusText);
                     })
                 }
             }).catch(error => {
-                setErrorMessage(error)
+                store.configStore.snackBarIsError = true;
+                store.configStore.snackBarMessage = `An error occurred: ${error}`
+                store.configStore.openSnackBar = true;
                 console.error('There has been a problem with your fetch operation:', error);
             })
 
@@ -100,16 +101,7 @@ const UIDInputModal: FC<Props> = ({ stateName }: Props) => {
                 </DialogActions>
             </DialogContent>
         </Dialog>
-        <Snackbar open={openErrorMessage} autoHideDuration={SnackBarCloseTime} onClose={() => { setOpenErrorMessage(false) }}>
-            <Alert onClose={() => { setOpenErrorMessage(false); setErrorMessage("") }} severity="error">
-                An error occured: {errorMessage}
-            </Alert>
-        </Snackbar>
-        <Snackbar open={openSuccessMessage} autoHideDuration={SnackBarCloseTime} onClose={() => { setOpenSuccess(false) }}>
-            <Alert onClose={() => { setOpenSuccess(false); }} severity="success">
-                State saved!
-            </Alert>
-        </Snackbar>
+
     </div>)
 }
 

--- a/frontend/src/Components/Utilities/LeftToolBox/LeftToolBox.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/LeftToolBox.tsx
@@ -3,7 +3,6 @@ import { max } from "d3"
 import { observer } from "mobx-react"
 import { FC, useEffect, useState } from "react"
 import { stateUpdateWrapperUseJSON } from "../../../Interfaces/StateChecker"
-import { useStyles } from "../../../Presets/StyledComponents"
 import FilterBoard from "../FilterInterface/FilterBoard"
 import CurrentSelected from "./CurrentSelected"
 import CurrentView from "./CurrentView"
@@ -17,7 +16,6 @@ const LeftToolBox: FC<Props> = ({ totalCaseNum }: Props) => {
     const [surgeryList, setSurgeryList] = useState<any[]>([]);
     const [maxCaseCount, setMaxCaseCount] = useState(0);
     const [tabValue, setTabValue] = useState(0);
-    const styles = useStyles();
     const handleChange = (event: any, newValue: any) => {
         setTabValue(newValue);
     };

--- a/frontend/src/Components/Utilities/TopMenu/RegularModeMenu.tsx
+++ b/frontend/src/Components/Utilities/TopMenu/RegularModeMenu.tsx
@@ -133,7 +133,7 @@ const RegularModeMenu: FC = () => {
             <StateManagementSuite />
 
 
-            <IconButton disabled={store.isAtRoot} onClick={() => { store.chartStore.clearAllCharts() }}>
+            <IconButton disabled={store.isAtRoot} onClick={() => { store.chartStore.clearAllCharts(); store.configStore.loadedStateName = "" }}>
                 <Tooltip title={<div>  <p className={styles.tooltipFont}>Clear All Charts</p></div>}>
                     <DeleteIcon />
                 </Tooltip>

--- a/frontend/src/Components/Utilities/TopMenu/RegularModeMenu.tsx
+++ b/frontend/src/Components/Utilities/TopMenu/RegularModeMenu.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react";
 import { useContext, useState, FC } from "react";
 import InsertChartIcon from '@material-ui/icons/InsertChart';
 import Store from "../../../Interfaces/Store";
-import { logoutHandler } from "../../../Interfaces/UserManagement";
+import { logoutHandler, simulateAPIClick } from "../../../Interfaces/UserManagement";
 import BugReportOutlinedIcon from '@material-ui/icons/BugReportOutlined';
 import { useStyles } from "../../../Presets/StyledComponents";
 import AddModeTopMenu from "./AddModeTopMenu";
@@ -14,6 +14,7 @@ import UndoRedoButtons from "./UndoRedoButtons";
 import FormatSizeIcon from '@material-ui/icons/FormatSize';
 import StateManagementSuite from "./StateManagementSuite";
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
+import SaveIcon from '@material-ui/icons/Save';
 import InfoDialog from "../../Modals/InfoDialog";
 import DeleteIcon from '@material-ui/icons/Delete';
 import MoreVert from "@material-ui/icons/MoreVert";
@@ -46,15 +47,47 @@ const RegularModeMenu: FC = () => {
     };
 
 
+    const updateState = () => {
+        const csrftoken = simulateAPIClick()
+        fetch(`${process.env.REACT_APP_QUERY_URL}state`, {
+            method: `PUT`,
+            credentials: "include",
+            headers: {
+                'Accept': 'application/x-www-form-urlencoded',
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-CSRFToken': csrftoken || '',
+                "Access-Control-Allow-Origin": 'https://bloodvis.chpc.utah.edu',
+                "Access-Control-Allow-Credentials": "true",
+            },
+            body: JSON.stringify({ old_name: store.configStore.loadedStateName, new_name: store.configStore.loadedStateName, new_definition: store.provenance.exportState(false) })
+        }).then(response => {
+            if (response.status === 200) {
+                store.configStore.snackBarIsError = false;
+                store.configStore.snackBarMessage = "State updated!";
+                store.configStore.openSnackBar = true;
+            } else {
+                response.text().then(error => {
+                    store.configStore.snackBarIsError = true;
+                    store.configStore.snackBarMessage = `An error occurred: ${response.statusText}`;
+                    store.configStore.openSnackBar = true;
+                })
+            }
+        }).catch(error => {
+            store.configStore.snackBarIsError = true;
+            store.configStore.snackBarMessage = `An error occurred: ${error}`;
+            store.configStore.openSnackBar = true;
+        })
+    }
+
+
+
+
 
     const regularMenu = (
 
 
 
         <Toolbar className={styles.toolbarPaddingControl}>
-
-
-
 
 
             <a href="https://healthcare.utah.edu" target="_blank">
@@ -103,6 +136,12 @@ const RegularModeMenu: FC = () => {
             <IconButton disabled={store.isAtRoot} onClick={() => { store.chartStore.clearAllCharts() }}>
                 <Tooltip title={<div>  <p className={styles.tooltipFont}>Clear All Charts</p></div>}>
                     <DeleteIcon />
+                </Tooltip>
+            </IconButton>
+
+            <IconButton disabled={store.configStore.loadedStateName.length === 0} onClick={updateState}>
+                <Tooltip title={<div>  <p className={styles.tooltipFont}>{`Save to ${store.configStore.loadedStateName}`} </p></div>}>
+                    <SaveIcon />
                 </Tooltip>
             </IconButton>
 

--- a/frontend/src/Components/Utilities/TopMenu/StateManagementSuite.tsx
+++ b/frontend/src/Components/Utilities/TopMenu/StateManagementSuite.tsx
@@ -57,6 +57,7 @@ const StateManagementSuite: FC = () => {
         <div className={useStyles().centerAlignment}>
             <Button variant="outlined" onClick={handleClick} aria-controls="simple-menu" aria-haspopup="true"  >States</Button>
             <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={() => handleClose()}>
+                <MenuItem>Update State?</MenuItem>
                 <NestedMenuItem parentMenuOpen={Boolean(anchorEl)} label="Load Saved State">
                     {store.configStore.savedState.length > 0 ? store.configStore.savedState.map((d) => {
                         return (

--- a/frontend/src/Components/Utilities/TopMenu/StateManagementSuite.tsx
+++ b/frontend/src/Components/Utilities/TopMenu/StateManagementSuite.tsx
@@ -6,6 +6,7 @@ import Store from "../../../Interfaces/Store"
 import { useStyles } from "../../../Presets/StyledComponents"
 import ManageStateDialog from "../../Modals/ManageStateDialog"
 import SaveStateModal from "../../Modals/SaveStateModal";
+import { simulateAPIClick } from "../../../Interfaces/UserManagement";
 
 const StateManagementSuite: FC = () => {
     const styles = useStyles();
@@ -25,13 +26,16 @@ const StateManagementSuite: FC = () => {
     // // const [listOfSavedState, setListOfSavedState] = useState<string[]>([])
 
     async function fetchSavedStates() {
-        const res = await fetch(`${process.env.REACT_APP_QUERY_URL}state`)
-        const result = await res.json()
-        if (result) {
-            const resultList = result.map((d: any[]) => d);
-            // stateUpdateWrapperUseJSON(listOfSavedState, resultList, setListOfSavedState)
-            store.configStore.savedState = resultList;
-        }
+        fetch(`${process.env.REACT_APP_QUERY_URL}state`)
+            .then(result => result.json())
+            .then(result => {
+                if (result) {
+                    const resultList = result.map((d: any[]) => d)
+                    store.configStore.savedState = resultList;
+                }
+            }).catch(r => {
+                console.log("failed to fetch states")
+            })
     }
 
     useEffect(() => {
@@ -55,11 +59,46 @@ const StateManagementSuite: FC = () => {
         store.provenance.importState(result.definition)
     }
 
+    const updateStateFromSelection = (stateName: string) => {
+        const csrftoken = simulateAPIClick()
+        fetch(`${process.env.REACT_APP_QUERY_URL}state`, {
+            method: `PUT`,
+            credentials: "include",
+            headers: {
+                'Accept': 'application/x-www-form-urlencoded',
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-CSRFToken': csrftoken || '',
+                "Access-Control-Allow-Origin": 'https://bloodvis.chpc.utah.edu',
+                "Access-Control-Allow-Credentials": "true",
+            },
+            body: JSON.stringify({ old_name: stateName, new_name: stateName, new_definition: store.provenance.exportState(false) })
+        }).then(response => {
+            if (response.status === 200) {
+                store.configStore.snackBarIsError = false;
+                store.configStore.snackBarMessage = "State updated!";
+                store.configStore.openSnackBar = true;
+            } else {
+                response.text().then(error => {
+                    store.configStore.snackBarIsError = true;
+                    store.configStore.snackBarMessage = `An error occurred: ${response.statusText}`;
+                    store.configStore.openSnackBar = true;
+                })
+            }
+        }).catch(error => {
+            store.configStore.snackBarIsError = true;
+            store.configStore.snackBarMessage = `An error occurred: ${error}`;
+            store.configStore.openSnackBar = true;
+        })
+    }
+
+
+
+
     return (
         <div className={styles.centerAlignment}>
             <Button variant="outlined" onClick={handleClick} aria-controls="simple-menu" aria-haspopup="true"  >States</Button>
             <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={() => handleClose()}>
-                <MenuItem>Update State?</MenuItem>
+
                 <NestedMenuItem parentMenuOpen={Boolean(anchorEl)} label="Load Saved State">
                     {store.configStore.savedState.length > 0 ? store.configStore.savedState.map((d) => {
                         return (
@@ -67,19 +106,37 @@ const StateManagementSuite: FC = () => {
                                 key={`share${d}`}
                                 onClick={() => {
                                     handleClose();
-                                    loadSavedState(d)
+                                    loadSavedState(d);
+                                    store.configStore.loadedStateName = d;
                                 }}>
                                 {d}
                             </MenuItem>)
                     }) : <MenuItem disabled>No Available</MenuItem>}
                 </NestedMenuItem>
+
+
+                <NestedMenuItem parentMenuOpen={Boolean(anchorEl)} label="Save As ...">
+                    {store.configStore.savedState.length > 0 ? store.configStore.savedState.map((d) => {
+                        return (
+                            <MenuItem
+                                key={`share${d}`}
+                                onClick={() => {
+                                    handleClose();
+                                    updateStateFromSelection(d)
+                                }}>
+                                {d}
+                            </MenuItem>)
+                    }) : <MenuItem disabled>No Available</MenuItem>}
+                </NestedMenuItem>
+
                 {/* TODO add presets. */}
+
                 <NestedMenuItem parentMenuOpen={Boolean(anchorEl)} label="Load from Preset">
                     <MenuItem>Preset 1</MenuItem>
                     <MenuItem>Preset 2</MenuItem>
                     <MenuItem>Preset 3</MenuItem>
                 </NestedMenuItem>
-                <MenuItem onClick={() => { handleClose(); store.configStore.openSaveStateDialog = true; }}>Save State</MenuItem>
+                <MenuItem onClick={() => { handleClose(); store.configStore.openSaveStateDialog = true; }}>Save as a New State</MenuItem>
                 <MenuItem onClick={() => { handleClose(); store.configStore.openManageStateDialog = true; }}>Manage Saved States</MenuItem>
             </Menu>
             <ManageStateDialog />

--- a/frontend/src/Components/Utilities/TopMenu/StateManagementSuite.tsx
+++ b/frontend/src/Components/Utilities/TopMenu/StateManagementSuite.tsx
@@ -104,6 +104,7 @@ const StateManagementSuite: FC = () => {
                         return (
                             <MenuItem
                                 key={`share${d}`}
+
                                 onClick={() => {
                                     handleClose();
                                     loadSavedState(d);

--- a/frontend/src/Components/Utilities/TopMenu/StateManagementSuite.tsx
+++ b/frontend/src/Components/Utilities/TopMenu/StateManagementSuite.tsx
@@ -1,4 +1,4 @@
-import { Button, Grid, Menu, MenuItem } from "@material-ui/core"
+import { Button, Menu, MenuItem } from "@material-ui/core"
 import { observer } from "mobx-react"
 import { FC, useEffect, useState, useContext } from "react"
 import NestedMenuItem from "material-ui-nested-menu-item";
@@ -6,7 +6,6 @@ import Store from "../../../Interfaces/Store"
 import { useStyles } from "../../../Presets/StyledComponents"
 import ManageStateDialog from "../../Modals/ManageStateDialog"
 import SaveStateModal from "../../Modals/SaveStateModal";
-import { simulateAPIClick } from "../../../Interfaces/UserManagement";
 
 const StateManagementSuite: FC = () => {
     const styles = useStyles();
@@ -59,37 +58,6 @@ const StateManagementSuite: FC = () => {
         store.provenance.importState(result.definition)
     }
 
-    const updateStateFromSelection = (stateName: string) => {
-        const csrftoken = simulateAPIClick()
-        fetch(`${process.env.REACT_APP_QUERY_URL}state`, {
-            method: `PUT`,
-            credentials: "include",
-            headers: {
-                'Accept': 'application/x-www-form-urlencoded',
-                'Content-Type': 'application/x-www-form-urlencoded',
-                'X-CSRFToken': csrftoken || '',
-                "Access-Control-Allow-Origin": 'https://bloodvis.chpc.utah.edu',
-                "Access-Control-Allow-Credentials": "true",
-            },
-            body: JSON.stringify({ old_name: stateName, new_name: stateName, new_definition: store.provenance.exportState(false) })
-        }).then(response => {
-            if (response.status === 200) {
-                store.configStore.snackBarIsError = false;
-                store.configStore.snackBarMessage = "State updated!";
-                store.configStore.openSnackBar = true;
-            } else {
-                response.text().then(error => {
-                    store.configStore.snackBarIsError = true;
-                    store.configStore.snackBarMessage = `An error occurred: ${response.statusText}`;
-                    store.configStore.openSnackBar = true;
-                })
-            }
-        }).catch(error => {
-            store.configStore.snackBarIsError = true;
-            store.configStore.snackBarMessage = `An error occurred: ${error}`;
-            store.configStore.openSnackBar = true;
-        })
-    }
 
 
 
@@ -109,21 +77,6 @@ const StateManagementSuite: FC = () => {
                                     handleClose();
                                     loadSavedState(d);
                                     store.configStore.loadedStateName = d;
-                                }}>
-                                {d}
-                            </MenuItem>)
-                    }) : <MenuItem disabled>No Available</MenuItem>}
-                </NestedMenuItem>
-
-
-                <NestedMenuItem parentMenuOpen={Boolean(anchorEl)} label="Save As ...">
-                    {store.configStore.savedState.length > 0 ? store.configStore.savedState.map((d) => {
-                        return (
-                            <MenuItem
-                                key={`share${d}`}
-                                onClick={() => {
-                                    handleClose();
-                                    updateStateFromSelection(d)
                                 }}>
                                 {d}
                             </MenuItem>)

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -45,9 +45,9 @@ const Dashboard: FC = () => {
                     <DataRetrieval />
                 </> : <></>}
 
-            <Snackbar open={store.configStore.openNoteSaveSuccessMessage} autoHideDuration={SnackBarCloseTime} onClose={() => { store.configStore.openNoteSaveSuccessMessage = false }}>
-                <Alert onClose={() => { store.configStore.openNoteSaveSuccessMessage = false }} severity="success">
-                    Note saved locally!
+            <Snackbar open={store.configStore.openSnackBar} autoHideDuration={SnackBarCloseTime} onClose={() => { store.configStore.openSnackBar = false }}>
+                <Alert onClose={() => { store.configStore.openSnackBar = false }} severity={store.configStore.snackBarIsError ? "error" : "success"}>
+                    {store.configStore.snackBarMessage}
                 </Alert>
             </Snackbar>
         </div>

--- a/frontend/src/Interfaces/ProjectConfigStore.ts
+++ b/frontend/src/Interfaces/ProjectConfigStore.ts
@@ -49,7 +49,7 @@ export class ProjectConfigStore {
         this.filterRange = { PRBC_UNITS: 0, FFP_UNITS: 0, PLT_UNITS: 0, CRYO_UNITS: 0, CELL_SAVER_ML: 0, PREOP_HGB: 0, POSTOP_HGB: 0 };
         this.stateToUpdate = ""
 
-        this.savedState = []
+        this.savedState = ["asdfkjhasdhahahahahahahlongstate"]
         makeAutoObservable(this)
     }
 

--- a/frontend/src/Interfaces/ProjectConfigStore.ts
+++ b/frontend/src/Interfaces/ProjectConfigStore.ts
@@ -49,7 +49,7 @@ export class ProjectConfigStore {
         this.filterRange = { PRBC_UNITS: 0, FFP_UNITS: 0, PLT_UNITS: 0, CRYO_UNITS: 0, CELL_SAVER_ML: 0, PREOP_HGB: 0, POSTOP_HGB: 0 };
         this.stateToUpdate = ""
 
-        this.savedState = ["asdfkjhasdhahahahahahahlongstate"]
+        this.savedState = ["asdfkjhasdhah-ahahaha-hahlongstateasdfkjhasd-hahahahaha-hahlongstateasdfkjhasdhahahaha-hahahlongst-ateasdfkjhasdhaha-hahahahahlongstateasdfkjhasdhaha-hahahaha-hlongstateasdfk-jhasdhahahahahahahl-ongstateasdfkjhasdhahahaha-hahahlongst-ateasdfkjhasdh-ahahahahahahl-ongstate"]
         makeAutoObservable(this)
     }
 

--- a/frontend/src/Interfaces/ProjectConfigStore.ts
+++ b/frontend/src/Interfaces/ProjectConfigStore.ts
@@ -16,12 +16,15 @@ export class ProjectConfigStore {
     openCostInputModal: boolean;
     openStateAccessControl: boolean;
     openAboutDialog: boolean;
-
-    openNoteSaveSuccessMessage: boolean;
+    loadedStateName: string;
+    openSnackBar: boolean;
+    snackBarMessage: string;
     largeFont: boolean;
     savedState: string[];
     filterRange: any;
+    snackBarIsError: boolean;
     privateMode: boolean;
+    stateToUpdate: string;
 
     constructor(rootstore: RootStore) {
         this.rootStore = rootstore;
@@ -34,12 +37,18 @@ export class ProjectConfigStore {
         this.openSaveStateDialog = false;
         this.openManageStateDialog = false;
         this.openShareUIDDialog = false;
-        this.openNoteSaveSuccessMessage = false;
 
+        this.openSnackBar = false;
+        this.snackBarMessage = "";
+        this.snackBarIsError = false;
+
+        this.loadedStateName = ""
         this.openCostInputModal = false;
         this.openStateAccessControl = false;
         this.openAboutDialog = false;
         this.filterRange = { PRBC_UNITS: 0, FFP_UNITS: 0, PLT_UNITS: 0, CRYO_UNITS: 0, CELL_SAVER_ML: 0, PREOP_HGB: 0, POSTOP_HGB: 0 };
+        this.stateToUpdate = ""
+
         this.savedState = []
         makeAutoObservable(this)
     }

--- a/frontend/src/Interfaces/ProjectConfigStore.ts
+++ b/frontend/src/Interfaces/ProjectConfigStore.ts
@@ -49,7 +49,7 @@ export class ProjectConfigStore {
         this.filterRange = { PRBC_UNITS: 0, FFP_UNITS: 0, PLT_UNITS: 0, CRYO_UNITS: 0, CELL_SAVER_ML: 0, PREOP_HGB: 0, POSTOP_HGB: 0 };
         this.stateToUpdate = ""
 
-        this.savedState = ["asdfkjhasdhah-ahahaha-hahlongstateasdfkjhasd-hahahahaha-hahlongstateasdfkjhasdhahahaha-hahahlongst-ateasdfkjhasdhaha-hahahahahlongstateasdfkjhasdhaha-hahahaha-hlongstateasdfk-jhasdhahahahahahahl-ongstateasdfkjhasdhahahaha-hahahlongst-ateasdfkjhasdh-ahahahahahahl-ongstate"]
+        this.savedState = []
         makeAutoObservable(this)
     }
 


### PR DESCRIPTION
- [x] Add an easy icon to directly update state with the same name, if the current view is loaded from a state.
- [x] added updating state by clicking the pen icon in manage state.
- [x] added "save as" to choose an already existing state name (not sure this makes sense. We can delete this if it is confusing)
- [x] better organizing all snack bar to a single component. So all different modal, etc will make the same snack bar appear and update the error message.  