### PR TITLE
Add cpt codes to surgery query

### DIFF
--- a/backend/api/api/views.py
+++ b/backend/api/api/views.py
@@ -227,7 +227,8 @@ def fetch_surgery(request):
             # Use the first column of the query (visit_no), to get the index of data to update
             index = visit_nos.index(visit[0])
             cleaned_cpt = [cpt for cpt in cpts if cpt[1] == visit[1]]
-            #cleaned_cpt = cpts[cpts["db_code_desc"] == visit[1]]["clean_name"] if visit[1] in cpts["db_code_desc"] else None
+
+            # cleaned_cpt[0][2] since we want the first cpt that matched the description and the third field from the cpt table
             data[index]["cpt"] = list(set(data[index]["cpt"] + [cleaned_cpt[0][2]])) if cleaned_cpt else data[index]["cpt"]
 
         return JsonResponse({"result": data})

--- a/backend/api/api/views.py
+++ b/backend/api/api/views.py
@@ -38,6 +38,7 @@ DE_IDENT_FIELDS = {
     "billing_code": "CODE",
     "case_date": "DI_CASE_DATE",
     "case_id": "DI_CASE_ID",
+    "code_desc": "CODE_DESC",
     "death_date": "DI_DEATH_DATE",
     "dose_unit_desc": "DOSE_UNIT_DESC",
     "draw_dtm": "DI_DRAW_DTM",
@@ -177,6 +178,7 @@ def fetch_surgery(request):
 
         command = f"""
         SELECT
+            SURG.{FIELDS_IN_USE.get('visit_no')},
             SURG.{FIELDS_IN_USE.get('case_date')},
             SURG.{FIELDS_IN_USE.get('surgery_start_time')},
             SURG.{FIELDS_IN_USE.get('surgery_end_time')},
@@ -192,9 +194,40 @@ def fetch_surgery(request):
         result = execute_sql(command, id=case_id)
         data_dict = data_dictionary()
         data = [
-            dict(zip([data_dict[key[0]] for key in result.description], row))
+            dict(zip([data_dict[key[0]] for key in result.description[1:]] + ["cpt"], row[1:] + [[]]))
             for row in result
         ]
+
+        # Get the CPT information for each visit number
+        visit_nos = [row[0] for row in result]
+        visit_bind_names = [f":visit_no{str(i)}" for i in range(len(visit_nos))]
+        visit_filters_safe_sql = (
+            f"AND BLNG.{FIELDS_IN_USE.get('visit_no')} IN ({','.join(visit_bind_names)}) "
+            if visit_nos != []
+            else ""
+        )
+
+        visit_command = f"""
+            SELECT
+                BLNG.{FIELDS_IN_USE.get('visit_no')},
+                BLNG.{FIELDS_IN_USE.get('code_desc')}
+            FROM CLIN_DM.BPU_CTS_DI_BILL_CODES_092920 BLNG
+            WHERE 1=1
+            {visit_filters_safe_sql}
+        """
+
+        visit_result = execute_sql(
+            visit_command,
+            zip(visit_bind_names, visit_nos),
+        )
+
+        cpts = cpt()
+
+        for visit in visit_result:
+            # Use the first column of the query (visit_no), to get the index of data to update
+            index = visit_nos.index(visit[0])
+            cleaned_cpt = cpts[cpts["db_code_desc"] == visit[1]]["clean_name"] if visit[1] in cpts["db_code_desc"] else None
+            data[index]["cpt"] = list(set(data[index]["cpt"] + []))
 
         return JsonResponse({"result": data})
     else:

--- a/frontend/src/Components/Utilities/DetailView/CaseInfo.tsx
+++ b/frontend/src/Components/Utilities/DetailView/CaseInfo.tsx
@@ -13,7 +13,7 @@ const CaseInfo: FC = () => {
     const [individualInfo, setIndividualInfo] = useState<any>(null);
     const store = useContext(Store);
     const styles = useStyles();
-    const { currentSelectPatient } = store.state
+    const { currentSelectPatient } = store.state;
 
     const generate_List_Items = () => {
         let result = [];
@@ -24,46 +24,48 @@ const CaseInfo: FC = () => {
                         <ListItem>
                             <ListItemText primary={AcronymDictionary[key] ? AcronymDictionary[key] : key} secondary={val as string} />
                         </ListItem>
-                    )
+                    );
                 }
             }
         }
-        return result
-    }
+        return result;
+    };
 
     useEffect(() => {
-        async function fetchIndividualInformaiton() {
+        async function fetchIndividualInformaiton () {
 
             if (currentSelectPatient) {
-                stateUpdateWrapperUseJSON(individualInfo, null, setIndividualInfo)
-                const fetchResult = await fetch(`${process.env.REACT_APP_QUERY_URL}fetch_patient?patient_id=${currentSelectPatient.PATIENT_ID}`)
+                stateUpdateWrapperUseJSON(individualInfo, null, setIndividualInfo);
+                const fetchResult = await fetch(`${process.env.REACT_APP_QUERY_URL}fetch_patient?patient_id=${currentSelectPatient.PATIENT_ID}`);
 
                 const fetchResultJson = await fetchResult.json();
                 const individualInfoJSON = fetchResultJson.result[0];
 
-                const fetchSurgery = await fetch(`${process.env.REACT_APP_QUERY_URL}fetch_surgery?case_id=${currentSelectPatient.CASE_ID}`)
+                const fetchSurgery = await fetch(`${process.env.REACT_APP_QUERY_URL}fetch_surgery?case_id=${currentSelectPatient.CASE_ID}`);
                 const fetchSurgeryJson = await fetchSurgery.json();
-                const surgeryInfo = fetchSurgeryJson.result[0];
+                let surgeryInfo = fetchSurgeryJson.result[0];
+                surgeryInfo["CPT Codes"] = surgeryInfo.cpt.join(', ');
+                delete surgeryInfo.cpt;
 
-                let final_result = Object.assign(individualInfoJSON, surgeryInfo)
+                let final_result = Object.assign(individualInfoJSON, surgeryInfo);
 
-                final_result = Object.assign(final_result, currentSelectPatient)
+                final_result = Object.assign(final_result, currentSelectPatient);
 
-                const outcomeAttributes = ["DEATH", "ECMO", "STROKE", "VENT", "AMICAR", "TXA", "B12"]
+                const outcomeAttributes = ["DEATH", "ECMO", "STROKE", "VENT", "AMICAR", "TXA", "B12"];
                 outcomeAttributes.forEach((attribute) => {
-                    final_result[attribute] = final_result[attribute] === 0 ? "No" : "Yes"
-                })
+                    final_result[attribute] = final_result[attribute] === 0 ? "No" : "Yes";
+                });
 
                 final_result.SURGERY_TYPE = SurgeryUrgencyArray[final_result.SURGERY_TYPE];
-                stateUpdateWrapperUseJSON(individualInfo, final_result, setIndividualInfo)
+                stateUpdateWrapperUseJSON(individualInfo, final_result, setIndividualInfo);
             }
             else {
-                stateUpdateWrapperUseJSON(individualInfo, null, setIndividualInfo)
+                stateUpdateWrapperUseJSON(individualInfo, null, setIndividualInfo);
             }
         }
-        fetchIndividualInformaiton()
+        fetchIndividualInformaiton();
 
-    }, [currentSelectPatient])
+    }, [currentSelectPatient]);
     return (<Container className={styles.containerWidth} style={{ height: "80vh", padding: "1px", visibility: currentSelectPatient ? "visible" : "hidden" }}>
 
         <List dense>
@@ -82,7 +84,7 @@ const CaseInfo: FC = () => {
             </ListSubheader>
             {individualInfo ? generate_List_Items() : <Container className={styles.centerAlignment}><CircularProgress /></Container>}
         </List>
-    </Container>)
-}
+    </Container>);
+};
 
-export default observer(CaseInfo)
+export default observer(CaseInfo);


### PR DESCRIPTION
Closes #188

Adds the logic to return all cleaned cpt code names from a surgery query. For example:

```
{
	"result": [
		{
			...
			"cpt": [
				"Thoracic Aorta Aneurysm Procedure",
				"CABG",
				"ECMO"
			]
		}
	]
}
```

A current by-product of this fix is that the visit number is now also returned as "hospital visit number" in the JSON. I guess that's not a huge issue, but we should probably not display that in the UI.