### PR TITLE
Add a count for procedures that happened without an overlap and add ability to query for those types of surgery in request transfused units

### DIFF
--- a/backend/api/api/views.py
+++ b/backend/api/api/views.py
@@ -157,11 +157,18 @@ def get_procedure_counts(request):
         # Count the raw number of procedures done
         total_counts = Counter([item for sublist in procedures_in_case for item in sublist])
 
+        # Get the CPTs that happened alone (didn't have any other co-occurrences)
+        all_single_cpt_cases = [y for y in [set(x) for x in procedures_in_case] if len(y) ==1]
+        exclusive_counts = Counter([item for sublist in all_single_cpt_cases for item in sublist])
+
         # Combine the raw count with co-occurrences
         combined_counts = [{
             "procedureName": proc_name,
             "count": total_counts[proc_name],
-            "overlapList": co_occur_counts[proc_name],
+            "overlapList": {
+                **co_occur_counts[proc_name],
+                **{f"Only {proc_name}": exclusive_counts[proc_name]},
+            }
         } for proc_name in total_counts]
 
         return JsonResponse({"result": combined_counts})

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,7 +13,6 @@ import { SurgeryUrgencyArray } from "./Presets/DataDict";
 import './App.css';
 import { checkIfCriteriaMet } from "./HelperFunctions/CaseListProducer";
 import useDeepCompareEffect from "use-deep-compare-effect";
-import { ProcedureStringGenerator } from "./HelperFunctions/ProcedureStringGenerator";
 
 export const DataContext = createContext<SingleCasePoint[]>([]);
 

--- a/frontend/src/Components/Utilities/LeftToolBox/SurgeryListViewer.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/SurgeryListViewer.tsx
@@ -84,7 +84,7 @@ const SurgeryListViewer: FC<Props> = ({ surgeryList, maxCaseCount }: Props) => {
                 }}>
 
                 <SurgeryDiv >
-                    {isSubSurgery ? `-> ${listItem.procedureName}` : listItem.procedureName}
+                    {isSubSurgery ? <>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{listItem.procedureName}</> : <>{isSelected ? `▼` : `►`}{listItem.procedureName}</>}
                 </SurgeryDiv>
                 <td>
                     <ListSVG widthInput={0.3 * width}>

--- a/frontend/src/Interfaces/Actions/SelectionActions.ts
+++ b/frontend/src/Interfaces/Actions/SelectionActions.ts
@@ -14,14 +14,24 @@ export const updateProcedureSelection = createAction<ApplicationState, [Procedur
     // if there is a parentProcedure, then this parent procedure must be already selected
     if (parentProcedure) {
         // find the parent procedure
-        const overlapList = state.proceduresSelection.filter(d => d.procedureName === parentProcedure)[0].overlapList;
+        let overlapList = state.proceduresSelection.filter(d => d.procedureName === parentProcedure)[0].overlapList;
         if (overlapList) {
+            // check if only is selected
+            if (overlapList.filter(d => d.procedureName.includes('Only'))) {
+                overlapList = overlapList.filter(d => !d.procedureName.includes('Only'));
+            }
+
             if (overlapList.filter(d => d.procedureName === newProcedureSelection.procedureName).length > 0) {
                 // this procedure was selected, we need to remove it
                 state.proceduresSelection.filter(d => d.procedureName === parentProcedure)[0].overlapList = overlapList.filter(d => d.procedureName !== newProcedureSelection.procedureName);
             } else {
                 // this procedure wasn't selected, add it.
-                state.proceduresSelection.filter(d => d.procedureName === parentProcedure)[0].overlapList?.push(newProcedureSelection);
+                if (newProcedureSelection.procedureName.includes('Only')) {
+                    state.proceduresSelection.filter(d => d.procedureName === parentProcedure)[0].overlapList = [newProcedureSelection];
+                } else {
+                    state.proceduresSelection.filter(d => d.procedureName === parentProcedure)[0].overlapList = overlapList;
+                    state.proceduresSelection.filter(d => d.procedureName === parentProcedure)[0].overlapList?.push(newProcedureSelection);
+                }
             }
         }
         // const procedureExist = parentProcedureItem.

--- a/frontend/src/Interfaces/ProjectConfigStore.ts
+++ b/frontend/src/Interfaces/ProjectConfigStore.ts
@@ -2,7 +2,6 @@ import { makeAutoObservable } from "mobx";
 import { BloodComponentOptions } from "../Presets/DataDict";
 import { changeBloodFilter, changeCostConfig, changeOutcomeFilter, changeSurgeryUrgencySelection, changeTestValueFilter, clearAllFilter, dateRangeChange, loadPreset, resetBloodFilter, resetTestValueFilter, toggleShowZero } from "./Actions/ProjectConfigActions";
 import { RootStore } from "./Store";
-import { ProcedureEntry } from "./Types/DataTypes";
 import { LayoutElement } from "./Types/LayoutTypes";
 
 export class ProjectConfigStore {


### PR DESCRIPTION
For example, this shows how many CABGs happened without co-occurring with another surgery type.

You can also request the `Only CABG` from `request_transfused_units` and it will return the cases that match. This should work with the AND/OR logic of the query 