### PR TITLE
Fix: Scatter Plot X-Axis Bin Labels (#307)

### DIFF
--- a/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisBand.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisBand.tsx
@@ -37,7 +37,7 @@ function CustomizedAxisBand({ scaleDomain, scaleRange, scalePadding }: Props) {
           <g key={idx}>
             <CustomAxisLine x1={x1} x2={x2} />
             <CustomAxisLineBox x={x1} width={x2 - x1} fill={idx % 2 === 1 ? secondaryGray : basicGray} />
-            <AxisText biggerFont={store.configStore.largeFont} x={x1 + 0.5 * (x2 - x1)}>{number}</AxisText>
+            <AxisText biggerFont={store.configStore.largeFont} x={x1} width={x2 - x1}>{number}</AxisText>
           </g>
         );
       })}


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #307 

### Give a longer description of what this PR addresses and why it's needed

**_Bug_**: Issue #307 Scatter plot x-axis bin labels did not contain text.
**_Fix_**: Scatter plot x-axis bin labels _now contain text._
**_Changes_**: 
- CustomizedAxisBand.tsx: Added a 'y' property to <AxisText> to vertically center text in bins.
- StyledSVGComponents.ts: Changed AxisText to 'styled.text'.

### Provide pictures/videos of the behavior before and after these changes (optional)
After:
![issue307](https://github.com/user-attachments/assets/5d161b62-8b89-4fe3-b8a3-1cd10bd85c55)


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
