### PR TITLE
Fix: Heatmap Attribute Data Scaling (#312)

### DIFF
--- a/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairViolin.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairViolin.tsx
@@ -34,10 +34,10 @@ type Props = {
  * @returns The x domain of the KDE from the data set.
  */
 function getAttributeXDomain(dataSet: ExtraPairPoint['data']) {
-  const allKdeX: number[] = [];
-  Object.values(dataSet).forEach((result) => {
+  
+  const allKdeX = Object.values(dataSet).flatMap((result) => {
     const originalKde = result.kdeArray;
-    allKdeX.push(...originalKde.map((point: { x: number }) => point.x));
+    return originalKde.map((point: { x: number }) => point.x);
   });
   return [min(allKdeX) ?? 0, max(allKdeX) ?? 20];
 }

--- a/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairViolin.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairViolin.tsx
@@ -34,7 +34,6 @@ type Props = {
  * @returns The x domain of the KDE from the data set.
  */
 function getAttributeXDomain(dataSet: ExtraPairPoint['data']) {
-  
   const allKdeX = Object.values(dataSet).flatMap((result) => result.kdeArray.map((point: { x: number }) => point.x));
   return [min(allKdeX) ?? 0, max(allKdeX) ?? 20];
 }
@@ -126,8 +125,8 @@ function ExtraPairViolin({
       </g>
       <line
         style={{ stroke: '#e5ab73', strokeWidth: '2', strokeDasharray: '5,5' }}
-        x1={valueScale(name === 'Preop HGB' ? HGB_HIGH_STANDARD : HGB_LOW_STANDARD)}
-        x2={valueScale(name === 'Preop HGB' ? HGB_HIGH_STANDARD : HGB_LOW_STANDARD)}
+        x1={valueScale(name === 'PREOP_HEMO' ? HGB_HIGH_STANDARD : HGB_LOW_STANDARD)}
+        x2={valueScale(name === 'PREOP_HEMO' ? HGB_HIGH_STANDARD : HGB_LOW_STANDARD)}
         opacity={name === 'DRG_WEIGHT' ? 0 : 1}
         y1={aggregationScale().range()[0]}
         y2={aggregationScale().range()[1] - 0.25 * aggregationScale().bandwidth()}

--- a/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairViolin.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairViolin.tsx
@@ -35,10 +35,7 @@ type Props = {
  */
 function getAttributeXDomain(dataSet: ExtraPairPoint['data']) {
   
-  const allKdeX = Object.values(dataSet).flatMap((result) => {
-    const originalKde = result.kdeArray;
-    return originalKde.map((point: { x: number }) => point.x);
-  });
+  const allKdeX = Object.values(dataSet).flatMap((result) => result.kdeArray.map((point: { x: number }) => point.x));
   return [min(allKdeX) ?? 0, max(allKdeX) ?? 20];
 }
 

--- a/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairViolin.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairViolin.tsx
@@ -128,7 +128,7 @@ function ExtraPairViolin({
         style={{ stroke: '#e5ab73', strokeWidth: '2', strokeDasharray: '5,5' }}
         x1={valueScale(name === 'Preop HGB' ? HGB_HIGH_STANDARD : HGB_LOW_STANDARD)}
         x2={valueScale(name === 'Preop HGB' ? HGB_HIGH_STANDARD : HGB_LOW_STANDARD)}
-        opacity={name === 'RISK' ? 0 : 1}
+        opacity={name === 'DRG_WEIGHT' ? 0 : 1}
         y1={aggregationScale().range()[0]}
         y2={aggregationScale().range()[1] - 0.25 * aggregationScale().bandwidth()}
       />

--- a/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairViolin.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/ExtraPairViolin.tsx
@@ -3,7 +3,7 @@ import {
 } from 'react';
 import { observer } from 'mobx-react';
 import {
-  scaleLinear, line, curveCatmullRom, format, scaleBand, select, axisBottom,
+  scaleLinear, line, min, max, curveCatmullRom, format, scaleBand, select, extent, axisBottom,
 } from 'd3';
 import { Tooltip } from '@mui/material';
 import styled from '@emotion/styled';
@@ -28,6 +28,20 @@ type Props = {
   secondaryMedianSet?: ExtraPairPoint['medianSet'];
 };
 
+/**
+ * Get the x domain of the KDE for the attribute.
+ * @param dataSet - The data set to get the domain from.
+ * @returns The x domain of the KDE from the data set.
+ */
+function getAttributeXDomain(dataSet: ExtraPairPoint['data']) {
+  const allKdeX: number[] = [];
+  Object.values(dataSet).forEach((result) => {
+    const originalKde = result.kdeArray;
+    allKdeX.push(...originalKde.map((point: { x: number }) => point.x));
+  });
+  return [min(allKdeX) ?? 0, max(allKdeX) ?? 20];
+}
+
 function ExtraPairViolin({
   kdeMax, dataSet, aggregationScaleDomain, aggregationScaleRange, medianSet, name, secondaryDataSet, secondaryMedianSet,
 }: Props) {
@@ -38,10 +52,12 @@ function ExtraPairViolin({
     return aggScale;
   }, [aggregationScaleDomain, aggregationScaleRange]);
 
-  const valueScale = scaleLinear().domain([0, 18]).range([0, ExtraPairWidth.Violin]);
-  if (name === 'RISK') {
-    valueScale.domain([0, 30]);
-  }
+  // Get the x domain dynamically for the attribute
+  const attributeXDomain = getAttributeXDomain(dataSet);
+  // Set x scale for the entire attribute (Violin plots, etc.)
+  const valueScale = scaleLinear()
+    .domain(attributeXDomain)
+    .range([0, ExtraPairWidth.Violin]);
 
   const lineFunction = useCallback(() => {
     const calculatedKdeRange = secondaryDataSet ? [-0.25 * aggregationScale().bandwidth(), 0.25 * aggregationScale().bandwidth()] : [-0.5 * aggregationScale().bandwidth(), 0.5 * aggregationScale().bandwidth()];

--- a/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/GeneratorExtraPair.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/ExtraPairPlots/GeneratorExtraPair.tsx
@@ -130,7 +130,7 @@ function GeneratorExtraPair({
         explanation = 'Percentage of Patients';
         break;
       case 'Violin':
-        explanation = nameInput === 'RISK' ? 'Scaled 0-30' : (`Scaled 0-18, line at ${nameInput as string === 'Preop HGB' ? HGB_HIGH_STANDARD : HGB_LOW_STANDARD}`);
+        explanation = nameInput === 'DRG_WEIGHT' ? 'Scaled 0-30' : (`Scaled 0-18, line at ${nameInput as string === 'Preop HGB' ? HGB_HIGH_STANDARD : HGB_LOW_STANDARD}`);
         break;
       case 'BarChart':
         explanation = `Scaled 0-${format('.4r')(max(Object.values(extraPairDataPoint.data)))}`;

--- a/frontend/src/HelperFunctions/ExtraPairDataGenerator.ts
+++ b/frontend/src/HelperFunctions/ExtraPairDataGenerator.ts
@@ -127,7 +127,7 @@ export const generateExtrapairPlotData = (aggregatedBy: string, hemoglobinDataSe
 
               // Create the KDE for the attribute using the computed min and max
               let pd = createpd(newData[prop], { width: 2, min: attributeMin, max: attributeMax });
-              // pd = [{ x: 0, y: 0 }].concat(pd);
+              pd = [{ x: 0, y: 0 }].concat(pd);
 
               if ((newData[prop] as any).length > 5) {
                 kdeMaxTemp = (max(pd, (val: any) => val.y) as any) > kdeMaxTemp ? max(pd, (val: any) => val.y) : kdeMaxTemp;

--- a/frontend/src/HelperFunctions/ExtraPairDataGenerator.ts
+++ b/frontend/src/HelperFunctions/ExtraPairDataGenerator.ts
@@ -103,79 +103,8 @@ export const generateExtrapairPlotData = (aggregatedBy: string, hemoglobinDataSe
           newExtraPairData.push(outcomeDataGenerate(aggregatedBy, 'IRON', 'Iron', data, hemoglobinDataSet));
           break;
 
-        case 'DRG_WEIGHT': {
-          // let temporaryDataHolder: any = {}
-          data.forEach((dataPoint: BasicAggregatedDatePoint) => {
-            temporaryDataHolder[dataPoint.aggregateAttribute] = [];
-            caseDictionary[dataPoint.aggregateAttribute] = new Set(dataPoint.caseIDList);
-          });
-          hemoglobinDataSet.forEach((ob: any) => {
-            if (temporaryDataHolder[ob[aggregatedBy]] && caseDictionary[ob[aggregatedBy]].has(ob.CASE_ID)) {
-              temporaryDataHolder[ob[aggregatedBy]].push(ob.DRG_WEIGHT);
-            }
-          });
-
-          // Compute the attribute-wide min and max for 'DRG_WEIGHT' AKA 'RISK'
-          const { attributeMin, attributeMax } = getAttributeMinMax(temporaryDataHolder);
-
-          for (const [key, value] of Object.entries(temporaryDataHolder)) {
-            medianData[key] = median(value as any);
-
-            // Create the KDE for the attribute using the computed min and max
-            let pd = createpd(value, { min: attributeMin, max: attributeMax });
-            // pd = [{ x: 0, y: 0 }].concat(pd);
-
-            if ((value as any).length > 5) {
-              kdeMaxTemp = (max(pd, (val: any) => val.y) as any) > kdeMaxTemp ? max(pd, (val: any) => val.y) : kdeMaxTemp;
-            }
-
-            const reversePd = pd.map((pair: any) => ({ x: pair.x, y: -pair.y })).reverse();
-            pd = pd.concat(reversePd);
-            newData[key] = { kdeArray: pd, dataPoints: value };
-          }
-          newExtraPairData.push({
-            name: variable, label: 'DRG Weight', data: newData, type: 'Violin', medianSet: medianData, kdeMax: kdeMaxTemp,
-          });
-          break;
-        }
-        case 'PREOP_HEMO': {
-          data.forEach((dataPoint: BasicAggregatedDatePoint) => {
-            newData[dataPoint.aggregateAttribute] = [];
-            caseDictionary[dataPoint.aggregateAttribute] = new Set(dataPoint.caseIDList);
-          });
-
-          hemoglobinDataSet.forEach((ob: SingleCasePoint) => {
-            const resultValue = ob.PREOP_HEMO;
-            if (newData[ob[aggregatedBy]] && resultValue > 0 && caseDictionary[ob[aggregatedBy]].has(ob.CASE_ID)) {
-              newData[ob[aggregatedBy]].push(resultValue);
-            }
-          });
-
-          // Compute the attribute-wide min and max for 'PREOP_HEMO'
-          const { attributeMin, attributeMax } = getAttributeMinMax(newData);
-
-          for (const prop in newData) {
-            if (Object.hasOwn(newData, prop)) {
-              medianData[prop] = median(newData[prop]);
-
-              // Create the KDE for the attribute using the computed min and max
-              let pd = createpd(newData[prop], { width: 2, min: attributeMin, max: attributeMax });
-              // pd = [{ x: 0, y: 0 }].concat(pd);
-
-              if ((newData[prop] as any).length > 5) {
-                kdeMaxTemp = (max(pd, (val: any) => val.y) as any) > kdeMaxTemp ? max(pd, (val: any) => val.y) : kdeMaxTemp;
-              }
-
-              const reversePd = pd.map((pair: any) => ({ x: pair.x, y: -pair.y })).reverse();
-              pd = pd.concat(reversePd);
-              newData[prop] = { kdeArray: pd, dataPoints: newData[prop] };
-            }
-          }
-          newExtraPairData.push({
-            name: 'PREOP_HEMO', label: 'Preop HGB', data: newData, type: 'Violin', medianSet: medianData, kdeMax: kdeMaxTemp,
-          });
-          break;
-        }
+        case 'DRG_WEIGHT':
+        case 'PREOP_HEMO':
         case 'POSTOP_HEMO': {
           // let newData = {} as any;
           data.forEach((dataPoint: BasicAggregatedDatePoint) => {
@@ -183,7 +112,7 @@ export const generateExtrapairPlotData = (aggregatedBy: string, hemoglobinDataSe
             caseDictionary[dataPoint.aggregateAttribute] = new Set(dataPoint.caseIDList);
           });
           hemoglobinDataSet.forEach((ob: any) => {
-            const resultValue = ob.POSTOP_HEMO;
+            const resultValue = ob[variable];
             if (newData[ob[aggregatedBy]] && resultValue > 0 && caseDictionary[ob[aggregatedBy]].has(ob.CASE_ID)) {
               newData[ob[aggregatedBy]].push(resultValue);
             }
@@ -210,7 +139,7 @@ export const generateExtrapairPlotData = (aggregatedBy: string, hemoglobinDataSe
             }
           }
           newExtraPairData.push({
-            name: 'POSTOP_HEMO', label: 'Postop HGB', data: newData, type: 'Violin', medianSet: medianData, kdeMax: kdeMaxTemp,
+            name: variable, label: variable, data: newData, type: 'Violin', medianSet: medianData, kdeMax: kdeMaxTemp,
           });
           break;
         }

--- a/frontend/src/HelperFunctions/ExtraPairDataGenerator.ts
+++ b/frontend/src/HelperFunctions/ExtraPairDataGenerator.ts
@@ -36,12 +36,7 @@ const outcomeDataGenerate = (aggregatedBy: string, name: string, label: string, 
  * @returns The min and max of the object.
  */
 function getAttributeMinMax(input: Record<string, number[]>): { attributeMin: number, attributeMax: number } {
-  let attributeData: number[] = [];
-  for (const key in input) {
-    if (Object.hasOwn(input, key)) {
-      attributeData = attributeData.concat(input[key]);
-    }
-  }
+  const attributeData = Object.values(input).flat();
   return { attributeMin: min(attributeData)!, attributeMax: max(attributeData)! };
 }
 

--- a/frontend/src/HelperFunctions/ExtraPairDataGenerator.ts
+++ b/frontend/src/HelperFunctions/ExtraPairDataGenerator.ts
@@ -103,7 +103,7 @@ export const generateExtrapairPlotData = (aggregatedBy: string, hemoglobinDataSe
           newExtraPairData.push(outcomeDataGenerate(aggregatedBy, 'IRON', 'Iron', data, hemoglobinDataSet));
           break;
 
-        case 'RISK': {
+        case 'DRG_WEIGHT': {
           // let temporaryDataHolder: any = {}
           data.forEach((dataPoint: BasicAggregatedDatePoint) => {
             temporaryDataHolder[dataPoint.aggregateAttribute] = [];
@@ -134,7 +134,7 @@ export const generateExtrapairPlotData = (aggregatedBy: string, hemoglobinDataSe
             newData[key] = { kdeArray: pd, dataPoints: value };
           }
           newExtraPairData.push({
-            name: 'RISK', label: 'DRG Weight', data: newData, type: 'Violin', medianSet: medianData, kdeMax: kdeMaxTemp,
+            name: variable, label: 'DRG Weight', data: newData, type: 'Violin', medianSet: medianData, kdeMax: kdeMaxTemp,
           });
           break;
         }

--- a/frontend/src/Presets/DataDict.ts
+++ b/frontend/src/Presets/DataDict.ts
@@ -46,7 +46,7 @@ export const OutcomeOptions: { key: typeof OUTCOMES[number]; value: string }[] =
   { key: 'AMICAR', value: 'Amicar' },
 ];
 
-export const EXTRA_PAIR_OPTIONS = [...OUTCOMES, 'PREOP_HEMO', 'POSTOP_HEMO', 'TOTAL_TRANS', 'PER_CASE', 'ZERO_TRANS', 'RISK'] as const;
+export const EXTRA_PAIR_OPTIONS = [...OUTCOMES, 'PREOP_HEMO', 'POSTOP_HEMO', 'TOTAL_TRANS', 'PER_CASE', 'ZERO_TRANS', 'DRG_WEIGHT'] as const;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const ExtraPairOptions: { key: typeof EXTRA_PAIR_OPTIONS[number]; value: string }[] = (OutcomeOptions as any).concat([
   { key: 'PREOP_HEMO', value: 'Preop HGB' },
@@ -54,7 +54,7 @@ export const ExtraPairOptions: { key: typeof EXTRA_PAIR_OPTIONS[number]; value: 
   { key: 'TOTAL_TRANS', value: 'Total Transfused' },
   { key: 'PER_CASE', value: 'Per Case' },
   { key: 'ZERO_TRANS', value: 'Zero Transfused' },
-  { key: 'RISK', value: 'APR-DRG Weight' },
+  { key: 'DRG_WEIGHT', value: 'APR-DRG Weight' },
 ]);
 
 const dumbbellValueOptions = [{ key: 'HGB_VALUE', value: 'Hemoglobin Value' }];
@@ -89,7 +89,6 @@ export const AcronymDictionary = {
   TVR: 'Tricuspid Valve Repair',
   PVR: 'Proliferative Vitreoretinopathy',
   VENT: 'Over 24 Hours Ventilator Usage',
-  RISK: 'Diagnosis-related Group Weight (Risk Score)',
   'Zero %': 'Zero Transfusion',
   DEATH: 'Death in hospital',
   STROKE: 'Stroke',


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #312 

### Give a longer description of what this PR addresses and why it's needed

Issue #312: Datapoints were scattered out-of-bounds in 'additional attribute' columns which contain violin plots

This PR:

- Changes the datapoint scaling from static domains to dynamic data-based domains.
- Ensures that all violin plots and datapoints (within each additional attribute) internally have the same horizontal scaling. 

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
![415358392-8511c9eb-36d0-44ef-b3d0-14896e750269](https://github.com/user-attachments/assets/ed331fc5-a725-483d-81f7-df2f845bcd80)


After:
![312](https://github.com/user-attachments/assets/bb7ff2cb-14c9-495f-b0a4-93428a4d0cea)


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
