### PR TITLE
Toggle defaults to 'on'

### DIFF
--- a/frontend/src/Components/Charts/CostBarChart.tsx
+++ b/frontend/src/Components/Charts/CostBarChart.tsx
@@ -95,7 +95,7 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
     store.selectionStore.selectSet(yAxisVar, (clickedElement as CostBarDataPoint).rowLabel[0].toString(), true);
   };
 
-  const [showPotential, setShowPotential] = useState(false);
+  const [showPotential, setShowPotential] = useState(true);
   const [bloodCostToChange, setBloodCostToChange] = useState('');
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [openCostInputDialog, setOpenCostInputDialog] = useState(false);


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #321 

### Give a longer description of what this PR addresses and why it's needed
Cost / Savings chart toggle defaults 'on'.

### Provide pictures/videos of the behavior before and after these changes (optional)

Default before:
![Screenshot 2025-03-04 at 9 41 03 AM](https://github.com/user-attachments/assets/964821d2-53b6-481b-8fe4-7af734552797)

Default after:
![Screenshot 2025-03-04 at 9 40 42 AM](https://github.com/user-attachments/assets/a8b0834b-a01e-44e9-8828-c4c0fb04f947)


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
