### PR TITLE
Reduce Dumbbell Chart Buttons (#329)

### DIFF
--- a/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
@@ -25,7 +25,7 @@ type Props = {
     svg: React.RefObject<SVGSVGElement>;
     xMin: number;
     xMax: number;
-    sortMode: string;
+    sortMode: 'preop' | 'postop' | 'gap';
     showPreop: boolean;
     showPostop: boolean;
 };
@@ -46,12 +46,12 @@ function DumbbellChart({
   const svgSelection = select(svg.current);
   const showGap = showPostop && showPreop;
 
-  const sortDataHelper = (originalData: DumbbellDataPoint[], sortModeInput: string) => {
+  const sortDataHelper = (originalData: DumbbellDataPoint[], sortModeInput: 'preop' | 'postop' | 'gap') => {
     const copyOfData: DumbbellDataPoint[] = JSON.parse(JSON.stringify(originalData));
     if (originalData.length > 0) {
       let tempSortedData: DumbbellDataPoint[] = [];
       switch (sortModeInput) {
-        case 'Postop':
+        case 'postop':
           tempSortedData = copyOfData.sort(
             (a, b) => {
               if (a.yVal === b.yVal) {
@@ -65,7 +65,7 @@ function DumbbellChart({
             },
           );
           break;
-        case 'Preop':
+        case 'preop':
           tempSortedData = copyOfData.sort(
             (a, b) => {
               if (a.yVal === b.yVal) {
@@ -79,7 +79,7 @@ function DumbbellChart({
             },
           );
           break;
-        case 'Gap':
+        case 'gap':
           tempSortedData = copyOfData.sort(
             (a, b) => {
               if (a.yVal === b.yVal) {

--- a/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
@@ -28,10 +28,9 @@ type Props = {
     sortMode: string;
     showPreop: boolean;
     showPostop: boolean;
-    showGap: boolean;
 };
 function DumbbellChart({
-  data, xAxisVar, dimensionHeight, dimensionWidth, svg, xMax, xMin, showGap, showPostop, showPreop, sortMode,
+  data, xAxisVar, dimensionHeight, dimensionWidth, svg, xMax, xMin, showPostop, showPreop, sortMode,
 }: Props) {
   const [averageForEachTransfused, setAverage] = useState<Record<number | string, { averageStart: number, averageEnd: number }>>({});
   const [sortedData, setSortedData] = useState<DumbbellDataPoint[]>([]);
@@ -45,6 +44,7 @@ function DumbbellChart({
 
   const currentOffset = OffsetDict.minimum;
   const svgSelection = select(svg.current);
+  const showGap = showPostop && showPreop;
 
   const sortDataHelper = (originalData: DumbbellDataPoint[], sortModeInput: string) => {
     const copyOfData: DumbbellDataPoint[] = JSON.parse(JSON.stringify(originalData));

--- a/frontend/src/Components/Charts/DumbbellChart/WrapperDumbbell.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/WrapperDumbbell.tsx
@@ -175,12 +175,6 @@ function WrapperDumbbell({ layout }: { layout: DumbbellLayoutElement }) {
           >
             Postop
           </Button>
-          <Button
-            css={showGap ? ButtonStyles.gapButtonActive : ButtonStyles.gapButtonOutline}
-            onClick={() => { setShowGap(!showGap); }}
-          >
-            Gap
-          </Button>
         </ButtonGroup>
 
       </Grid>

--- a/frontend/src/Components/Charts/DumbbellChart/WrapperDumbbell.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/WrapperDumbbell.tsx
@@ -140,25 +140,32 @@ function WrapperDumbbell({ layout }: { layout: DumbbellLayoutElement }) {
           size="small"
           aria-label="small outlined button group"
           orientation="vertical"
+          sx={{ minHeight: '75px' }}
         >
-          <Button
-            css={sortMode === 'Preop' ? ButtonStyles.preopButtonActive : ButtonStyles.preopButtonOutline}
-            onClick={() => { setSortMode('Preop'); }}
-          >
-            Preop
-          </Button>
-          <Button
-            css={sortMode === 'Postop' ? ButtonStyles.postopButtonActive : ButtonStyles.postopButtonOutline}
-            onClick={() => { setSortMode('Postop'); }}
-          >
-            Postop
-          </Button>
-          <Button
-            css={sortMode === 'Gap' ? ButtonStyles.gapButtonActive : ButtonStyles.gapButtonOutline}
-            onClick={() => { setSortMode('Gap'); }}
-          >
-            Gap
-          </Button>
+          {showPreop && (
+            <Button
+              css={sortMode === 'Preop' ? ButtonStyles.preopButtonActive : ButtonStyles.preopButtonOutline}
+              onClick={() => { setSortMode('Preop'); }}
+            >
+              Preop
+            </Button>
+          )}
+          {showPostop && (
+            <Button
+              css={sortMode === 'Postop' ? ButtonStyles.postopButtonActive : ButtonStyles.postopButtonOutline}
+              onClick={() => { setSortMode('Postop'); }}
+            >
+              Postop
+            </Button>
+          )}
+          {showPreop && showPostop && (
+            <Button
+              css={sortMode === 'Gap' ? ButtonStyles.gapButtonActive : ButtonStyles.gapButtonOutline}
+              onClick={() => { setSortMode('Gap'); }}
+            >
+              Gap
+            </Button>
+          )}
         </ButtonGroup>
         <DumbbellUtilTitle>Show</DumbbellUtilTitle>
         <ButtonGroup size="small" orientation="vertical">

--- a/frontend/src/Components/Charts/DumbbellChart/WrapperDumbbell.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/WrapperDumbbell.tsx
@@ -83,7 +83,6 @@ function WrapperDumbbell({ layout }: { layout: DumbbellLayoutElement }) {
   const [xMax, setXMax] = useState(0);
   const [sortMode, setSortMode] = useState('Postop');
   const [showPreop, setShowPreop] = useState(true);
-  const [showGap, setShowGap] = useState(true);
   const [showPostop, setShowPostop] = useState(true);
   const [data, setData] = useState<DumbbellDataPoint[]>([]);
 
@@ -186,7 +185,7 @@ function WrapperDumbbell({ layout }: { layout: DumbbellLayoutElement }) {
             <ChartStandardButtons chartID={chartId} />
           </ChartAccessoryDiv>
           <ChartSVG ref={svgRef}>
-            <DumbbellChart data={data} svg={svgRef} showGap={showGap} showPostop={showPostop} showPreop={showPreop} sortMode={sortMode} xAxisVar={xAxisVar} dimensionWidth={width} dimensionHeight={height} xMin={xMin} xMax={xMax} />
+            <DumbbellChart data={data} svg={svgRef} showPostop={showPostop} showPreop={showPreop} sortMode={sortMode} xAxisVar={xAxisVar} dimensionWidth={width} dimensionHeight={height} xMin={xMin} xMax={xMax} />
 
           </ChartSVG>
           <AnnotationForm chartI={chartId} annotationText={annotationText} />

--- a/frontend/src/Components/Charts/DumbbellChart/WrapperDumbbell.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/WrapperDumbbell.tsx
@@ -81,7 +81,7 @@ function WrapperDumbbell({ layout }: { layout: DumbbellLayoutElement }) {
   const [height, setHeight] = useState(0);
   const [xMin, setXMin] = useState(Infinity);
   const [xMax, setXMax] = useState(0);
-  const [sortMode, setSortMode] = useState('Postop');
+  const [sortMode, setSortMode] = useState<'preop' | 'postop' | 'gap'>('postop');
   const [showPreop, setShowPreop] = useState(true);
   const [showPostop, setShowPostop] = useState(true);
   const [data, setData] = useState<DumbbellDataPoint[]>([]);
@@ -144,24 +144,24 @@ function WrapperDumbbell({ layout }: { layout: DumbbellLayoutElement }) {
         >
           {showPreop && (
             <Button
-              css={sortMode === 'Preop' ? ButtonStyles.preopButtonActive : ButtonStyles.preopButtonOutline}
-              onClick={() => { setSortMode('Preop'); }}
+              css={sortMode === 'preop' ? ButtonStyles.preopButtonActive : ButtonStyles.preopButtonOutline}
+              onClick={() => { setSortMode('preop'); }}
             >
               Preop
             </Button>
           )}
           {showPostop && (
             <Button
-              css={sortMode === 'Postop' ? ButtonStyles.postopButtonActive : ButtonStyles.postopButtonOutline}
-              onClick={() => { setSortMode('Postop'); }}
+              css={sortMode === 'postop' ? ButtonStyles.postopButtonActive : ButtonStyles.postopButtonOutline}
+              onClick={() => { setSortMode('postop'); }}
             >
               Postop
             </Button>
           )}
           {showPreop && showPostop && (
             <Button
-              css={sortMode === 'Gap' ? ButtonStyles.gapButtonActive : ButtonStyles.gapButtonOutline}
-              onClick={() => { setSortMode('Gap'); }}
+              css={sortMode === 'gap' ? ButtonStyles.gapButtonActive : ButtonStyles.gapButtonOutline}
+              onClick={() => { setSortMode('gap'); }}
             >
               Gap
             </Button>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #329 

### Give a longer description of what this PR addresses and why it's needed

Issue 329 - There are now only two 'Show' options for dumbbell chart buttons. 'Sort By' buttons only appear when 'shown'.

### Provide pictures/videos of the behavior before and after these changes (optional)

Here are two different states of button clicks from this PR, demonstrating these changes: 
<img width="556" alt="Screenshot 2025-03-12 at 9 17 09 AM" src="https://github.com/user-attachments/assets/0121a86e-9154-484f-a4d3-91bba34cd1e1" />
<img width="554" alt="Screenshot 2025-03-12 at 9 17 30 AM" src="https://github.com/user-attachments/assets/9395d3d5-0396-497b-9956-ff739a2f886e" />

### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
