### PR TITLE
Dumbbell Chart Column Shading (#328)

### DIFF
--- a/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
@@ -7,16 +7,17 @@ import {
 } from 'd3';
 import Tooltip from '@mui/material/Tooltip';
 import { basicGray, secondaryGray } from '../../../Presets/Constants';
-import { AxisText, CustomAxisLine, CustomAxisLineBox } from '../../../Presets/StyledSVGComponents';
+import { AxisText, CustomAxisColumnBackground, CustomAxisLine, CustomAxisLineBox } from '../../../Presets/StyledSVGComponents';
 import Store from '../../../Interfaces/Store';
 
 function CustomizedAxisOrdinal({
-  numberList, scaleDomain, scaleRange, xAxisVar,
+  numberList, scaleDomain, scaleRange, xAxisVar, chartHeight,
 }: {
   scaleDomain: string;
   scaleRange: string;
   numberList: { num: number, indexEnding: number; }[];
   xAxisVar: string;
+  chartHeight: number;
 }) {
   const store = useContext(Store);
   const scale = useCallback(() => {
@@ -54,6 +55,7 @@ function CustomizedAxisOrdinal({
             <g key={idx}>
               <CustomAxisLine x1={x1} x2={x2} />
               <CustomAxisLineBox x={x1} width={x2 - x1} fill={idx % 2 === 1 ? secondaryGray : basicGray} />
+              <CustomAxisColumnBackground x={x1} width={x2 - x1} chartHeight={chartHeight} fill={idx % 2 === 1 ? 'white' : 'black'} />
               <Tooltip title={axisTextOutput(numberOb.num)}>
                 <AxisText biggerFont={store.configStore.largeFont} x={x1} width={x2 - x1}>{axisTextOutput(numberOb.num)}</AxisText>
               </Tooltip>

--- a/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
@@ -295,7 +295,7 @@ function DumbbellChart({
       <g className="axes">
         <g className="x-axis" />
         <g className="y-axis" transform={`translate(0,${dimensionHeight - currentOffset.bottom})`}>
-          <CustomizedAxisOrdinal scaleDomain={JSON.stringify(valueScale().domain())} scaleRange={JSON.stringify(valueScale().range())} numberList={numberList} xAxisVar={xAxisVar} />
+          <CustomizedAxisOrdinal scaleDomain={JSON.stringify(valueScale().domain())} scaleRange={JSON.stringify(valueScale().range())} numberList={numberList} xAxisVar={xAxisVar} chartHeight={dimensionHeight - currentOffset.bottom - currentOffset.top} />
         </g>
         <text className="x-label" />
         <text className="y-label" />

--- a/frontend/src/Presets/StyledSVGComponents.ts
+++ b/frontend/src/Presets/StyledSVGComponents.ts
@@ -100,6 +100,16 @@ export const CustomAxisLine = styled('line')`
     y2:0;
 `;
 
+interface CustomAxisColumnBackgroundProps {
+  chartHeight: number;
+}
+
+export const CustomAxisColumnBackground = styled('rect')<CustomAxisColumnBackgroundProps>`
+    height: ${({ chartHeight }) => chartHeight}px;
+    y: -${({ chartHeight }) => chartHeight}px;
+    opacity: 0.05;
+`;
+
 export const CustomAxisLineBox = styled('rect')`
     height: 13px;
     y:0px;


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #328 

### Give a longer description of what this PR addresses and why it's needed
Before:
- Difficult to visually separate columns

After: 
- Columns are visually separated by light shade of grey, alternating.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
![Screenshot 2025-03-13 at 3 13 47 PM](https://github.com/user-attachments/assets/88b7741a-692c-4453-bed8-3ec629edea11)

After:
![Screenshot 2025-03-13 at 3 14 10 PM](https://github.com/user-attachments/assets/87de722d-ff49-4555-9bb4-cbc598c13ba2)


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
