### PR TITLE
Hover Highlight - Dumbbell and Heatmap (#327)

### DIFF
--- a/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisBand.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisBand.tsx
@@ -4,18 +4,25 @@ import {
   scaleBand,
 } from 'd3';
 import { basicGray, secondaryGray } from '../../../Presets/Constants';
-import { AxisText, CustomAxisLine, CustomAxisLineBox } from '../../../Presets/StyledSVGComponents';
+import {
+  AxisText, CustomAxisColumnBackground, CustomAxisLine, CustomAxisLineBox,
+} from '../../../Presets/StyledSVGComponents';
 import Store from '../../../Interfaces/Store';
 
 type Props = {
   scaleDomain: string;
   scaleRange: string;
   scalePadding: number;
+  chartHeight: number;
+  hoveredColumn: number | null;
+  onColumnHover: (column: number | null) => void;
 };
 
-function CustomizedAxisBand({ scaleDomain, scaleRange, scalePadding }: Props) {
+function CustomizedAxisBand({
+  scaleDomain, scaleRange, scalePadding, chartHeight, hoveredColumn, onColumnHover,
+}: Props) {
   const store = useContext(Store);
-
+  const { hoverStore } = store;
   const scale = useCallback(() => {
     const domain = JSON.parse(scaleDomain);
     const range = JSON.parse(scaleRange);
@@ -34,9 +41,20 @@ function CustomizedAxisBand({ scaleDomain, scaleRange, scalePadding }: Props) {
         const x1 = scale()(number) || 0;
         const x2 = x1 + scale().bandwidth();
         return (
-          <g key={idx}>
+          <g
+            key={idx}
+            onMouseEnter={() => onColumnHover(idx)}
+            onMouseLeave={() => onColumnHover(null)}
+          >
             <CustomAxisLine x1={x1} x2={x2} />
             <CustomAxisLineBox x={x1} width={x2 - x1} fill={idx % 2 === 1 ? secondaryGray : basicGray} />
+            <CustomAxisColumnBackground
+              x={x1}
+              width={x2 - x1}
+              chartHeight={chartHeight}
+              fill={hoveredColumn === idx ? hoverStore.backgroundHoverColor : (idx % 2 === 1 ? 'white' : 'black')}
+              opacity={hoveredColumn === idx ? 0.5 : 0.05}
+            />
             <AxisText biggerFont={store.configStore.largeFont} x={x1} width={x2 - x1}>{number}</AxisText>
           </g>
         );

--- a/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
@@ -68,7 +68,7 @@ function CustomizedAxisOrdinal({
                 x={x1}
                 width={x2 - x1}
                 chartHeight={chartHeight}
-                fill={hoveredColumn === idx ? hoverStore.hoverColor : (idx % 2 === 1 ? 'white' : 'black')}
+                fill={hoveredColumn === idx ? hoverStore.backgroundHoverColor : (idx % 2 === 1 ? 'white' : 'black')}
                 opacity={hoveredColumn === idx ? 0.5 : 0.05}
               />
               <Tooltip title={axisTextOutput(numberOb.num)}>

--- a/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
@@ -7,19 +7,24 @@ import {
 } from 'd3';
 import Tooltip from '@mui/material/Tooltip';
 import { basicGray, secondaryGray } from '../../../Presets/Constants';
-import { AxisText, CustomAxisColumnBackground, CustomAxisLine, CustomAxisLineBox } from '../../../Presets/StyledSVGComponents';
+import {
+  AxisText, CustomAxisColumnBackground, CustomAxisLine, CustomAxisLineBox,
+} from '../../../Presets/StyledSVGComponents';
 import Store from '../../../Interfaces/Store';
 
 function CustomizedAxisOrdinal({
-  numberList, scaleDomain, scaleRange, xAxisVar, chartHeight,
+  numberList, scaleDomain, scaleRange, xAxisVar, chartHeight, hoveredColumn, onColumnHover,
 }: {
   scaleDomain: string;
   scaleRange: string;
   numberList: { num: number, indexEnding: number; }[];
   xAxisVar: string;
   chartHeight: number;
+  hoveredColumn: number | null;
+  onColumnHover: (column: number | null) => void;
 }) {
   const store = useContext(Store);
+  const { hoverStore } = store;
   const scale = useCallback(() => {
     const domain = JSON.parse(scaleDomain);
     const range = JSON.parse(scaleRange);
@@ -52,10 +57,20 @@ function CustomizedAxisOrdinal({
 
         if (x1 && x2) {
           return (
-            <g key={idx}>
+            <g
+              key={idx}
+              onMouseEnter={() => onColumnHover(idx)}
+              onMouseLeave={() => onColumnHover(null)}
+            >
               <CustomAxisLine x1={x1} x2={x2} />
               <CustomAxisLineBox x={x1} width={x2 - x1} fill={idx % 2 === 1 ? secondaryGray : basicGray} />
-              <CustomAxisColumnBackground x={x1} width={x2 - x1} chartHeight={chartHeight} fill={idx % 2 === 1 ? 'white' : 'black'} />
+              <CustomAxisColumnBackground
+                x={x1}
+                width={x2 - x1}
+                chartHeight={chartHeight}
+                fill={hoveredColumn === idx ? hoverStore.hoverColor : (idx % 2 === 1 ? 'white' : 'black')}
+                opacity={hoveredColumn === idx ? 0.5 : 0.05}
+              />
               <Tooltip title={axisTextOutput(numberOb.num)}>
                 <AxisText biggerFont={store.configStore.largeFont} x={x1} width={x2 - x1}>{axisTextOutput(numberOb.num)}</AxisText>
               </Tooltip>

--- a/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
@@ -32,7 +32,6 @@ type Props = {
 function DumbbellChart({
   data, xAxisVar, dimensionHeight, dimensionWidth, svg, xMax, xMin, showPostop, showPreop, sortMode,
 }: Props) {
-  const [hoveredColumn, setHoveredColumn] = useState<number | null>(null);
   const [averageForEachTransfused, setAverage] = useState<Record<number | string, { averageStart: number, averageEnd: number }>>({});
   const [sortedData, setSortedData] = useState<DumbbellDataPoint[]>([]);
   const [numberList, setNumberList] = useState<{ num: number, indexEnding: number; }[]>([]);
@@ -310,30 +309,12 @@ function DumbbellChart({
     return unselectedPatients.concat(selectedPatients);
   };
 
-  // Add a new handler that updates both the local hoveredColumn state and the store.
-  const handleColumnHover = (columnIndex: number | null) => {
-    setHoveredColumn(columnIndex);
-    if (columnIndex !== null) {
-      // Filter the sorted data for cases within the hovered column.
-      const pointsInColumn = sortedData.filter(
-        (dp: DumbbellDataPoint) => dp.yVal === columnIndex,
-      );
-      // Update the hover store with all case IDs in that column
-      store.hoverStore.hoveredCaseIds = pointsInColumn.map(
-        (dp: DumbbellDataPoint) => dp.case.CASE_ID,
-      );
-    } else {
-      // Clear hovered cases when no column is hovered.
-      store.hoverStore.hoveredCaseIds = [];
-    }
-  };
-
   return (
     <>
       <g className="axes">
         <g className="x-axis" />
         <g className="y-axis" transform={`translate(0,${dimensionHeight - currentOffset.bottom})`}>
-          <CustomizedAxisOrdinal scaleDomain={JSON.stringify(valueScale().domain())} scaleRange={JSON.stringify(valueScale().range())} numberList={numberList} xAxisVar={xAxisVar} chartHeight={dimensionHeight - currentOffset.bottom - currentOffset.top} hoveredColumn={hoveredColumn} onColumnHover={handleColumnHover} />
+          <CustomizedAxisOrdinal scaleDomain={JSON.stringify(valueScale().domain())} scaleRange={JSON.stringify(valueScale().range())} numberList={numberList} xAxisVar={xAxisVar} chartHeight={dimensionHeight - currentOffset.bottom - currentOffset.top} data={sortedData} />
         </g>
         <text className="x-label" />
         <text className="y-label" />

--- a/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
@@ -32,6 +32,8 @@ type Props = {
 function DumbbellChart({
   data, xAxisVar, dimensionHeight, dimensionWidth, svg, xMax, xMin, showPostop, showPreop, sortMode,
 }: Props) {
+  const [hoveredColumn, setHoveredColumn] = useState<number | null>(null);
+  const [hoveredDataPoint, setHoveredDataPoint] = useState<DumbbellDataPoint | null>(null);
   const [averageForEachTransfused, setAverage] = useState<Record<number | string, { averageStart: number, averageEnd: number }>>({});
   const [sortedData, setSortedData] = useState<DumbbellDataPoint[]>([]);
   const [numberList, setNumberList] = useState<{ num: number, indexEnding: number; }[]>([]);
@@ -45,6 +47,26 @@ function DumbbellChart({
   const currentOffset = OffsetDict.minimum;
   const svgSelection = select(svg.current);
   const showGap = showPostop && showPreop;
+
+  // Update the hoverStore when data is hovered
+  useEffect(() => {
+    if (sortedData.length === 0) {
+      return;
+    }
+    // If a data point is hovered, set the hoveredCaseIds to the case ID of the data point. Otherwise, clear the hoveredCaseIds
+    if (hoveredDataPoint !== null) {
+      store.hoverStore.hoveredCaseIds = [hoveredDataPoint.case.CASE_ID];
+    }
+    // If a column is hovered, set the hoveredCaseIds to the case IDs in the hovered column
+    if (hoveredColumn !== null) {
+      // Get the data points in the column. TODO: Change "yVal" to the correct column name
+      const pointsInColumn = sortedData.filter(
+        (dp: DumbbellDataPoint) => dp.yVal === hoveredColumn,
+      );
+      // Set the store's hoveredCaseIds to the case IDs in the hovered column
+      store.hoverStore.hoveredCaseIds = pointsInColumn.map((dp: DumbbellDataPoint) => dp.case.CASE_ID);
+    }
+  }, [sortedData, hoveredDataPoint, hoveredColumn, store.hoverStore]);
 
   const sortDataHelper = (originalData: DumbbellDataPoint[], sortModeInput: 'preop' | 'postop' | 'gap') => {
     const copyOfData: DumbbellDataPoint[] = JSON.parse(JSON.stringify(originalData));
@@ -254,6 +276,10 @@ function DumbbellChart({
       const xVal = (valueScale() as unknown as ScaleOrdinal<number, number>)(idx);
       const isSelectSet = decideIfSelectSet(dataPoint);
 
+      // Compute whether this dataPoint is currently hovered.
+      const isHovered = hoveredDataPoint?.case.CASE_ID === dataPoint.case.CASE_ID;
+      const { hoverColor } = store.hoverStore;
+
       if (xVal) {
         if (isSelectSet) {
           selectedPatients.push(
@@ -266,6 +292,10 @@ function DumbbellChart({
               showPreop={showPreop}
               circleYValStart={testValueScale()(dataPoint.startXVal)}
               circleYValEnd={testValueScale()(dataPoint.endXVal)}
+              isHovered={isHovered}
+              onMouseEnter={() => setHoveredDataPoint(dataPoint)}
+              onMouseLeave={() => setHoveredDataPoint(null)}
+              hoverColor={hoverColor}
               key={`dumbbell-${idx}`}
             />,
           );
@@ -280,6 +310,10 @@ function DumbbellChart({
               showPreop={showPreop}
               circleYValStart={testValueScale()(dataPoint.startXVal)}
               circleYValEnd={testValueScale()(dataPoint.endXVal)}
+              isHovered={isHovered}
+              onMouseEnter={() => setHoveredDataPoint(dataPoint)}
+              onMouseLeave={() => setHoveredDataPoint(null)}
+              hoverColor={hoverColor}
               key={`dumbbell-${idx}`}
             />,
           );
@@ -295,7 +329,7 @@ function DumbbellChart({
       <g className="axes">
         <g className="x-axis" />
         <g className="y-axis" transform={`translate(0,${dimensionHeight - currentOffset.bottom})`}>
-          <CustomizedAxisOrdinal scaleDomain={JSON.stringify(valueScale().domain())} scaleRange={JSON.stringify(valueScale().range())} numberList={numberList} xAxisVar={xAxisVar} chartHeight={dimensionHeight - currentOffset.bottom - currentOffset.top} />
+          <CustomizedAxisOrdinal scaleDomain={JSON.stringify(valueScale().domain())} scaleRange={JSON.stringify(valueScale().range())} numberList={numberList} xAxisVar={xAxisVar} chartHeight={dimensionHeight - currentOffset.bottom - currentOffset.top} hoveredColumn={hoveredColumn} onColumnHover={setHoveredColumn} />
         </g>
         <text className="x-label" />
         <text className="y-label" />

--- a/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
@@ -256,7 +256,7 @@ function DumbbellChart({
       const isSelectSet = decideIfSelectSet(dataPoint);
 
       // Compute whether this dataPoint is currently hovered.
-      const isHovered = store.hoverStore.hoveredCaseIds.includes(dataPoint.case.CASE_ID);
+      const hovered = store.hoverStore.hoveredCaseIds.includes(dataPoint.case.CASE_ID);
 
       if (xVal) {
         if (isSelectSet) {
@@ -270,7 +270,7 @@ function DumbbellChart({
               showPreop={showPreop}
               circleYValStart={testValueScale()(dataPoint.startXVal)}
               circleYValEnd={testValueScale()(dataPoint.endXVal)}
-              isHovered={isHovered}
+              hovered={hovered}
               onMouseEnter={() => {
                 store.hoverStore.hoveredCaseIds = [dataPoint.case.CASE_ID];
               }}
@@ -292,7 +292,7 @@ function DumbbellChart({
               showPreop={showPreop}
               circleYValStart={testValueScale()(dataPoint.startXVal)}
               circleYValEnd={testValueScale()(dataPoint.endXVal)}
-              isHovered={isHovered}
+              hovered={hovered}
               onMouseEnter={() => {
                 store.hoverStore.hoveredCaseIds = [dataPoint.case.CASE_ID];
               }}

--- a/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
@@ -358,10 +358,10 @@ function DumbbellChart({
             if (x1 && x2) {
               const toReturn = [];
               if (showPreop) {
-                toReturn.push(<DumbbellLine x1={x1} x2={x2} y1={beginY} y2={beginY} ispreop key={`db-line-${idx}`} />);
+                toReturn.push(<DumbbellLine x1={x1} x2={x2} y1={beginY} y2={beginY} isPreop key={`db-line-${idx}`} />);
               }
               if (showPostop) {
-                toReturn.push(<DumbbellLine x1={x1} x2={x2} y1={endY} y2={endY} ispreop={false} key={`db-line-${idx}-2`} />);
+                toReturn.push(<DumbbellLine x1={x1} x2={x2} y1={endY} y2={endY} isPreop={false} key={`db-line-${idx}-2`} />);
               }
               return ([
                 ...toReturn,

--- a/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
@@ -277,7 +277,7 @@ function DumbbellChart({
               onMouseLeave={() => {
                 store.hoverStore.hoveredCaseIds = [];
               }}
-              hoverColor={store.hoverStore.hoverColor}
+              hoverColor={store.hoverStore.smallHoverColor}
               key={`dumbbell-${idx}`}
             />,
           );
@@ -299,7 +299,7 @@ function DumbbellChart({
               onMouseLeave={() => {
                 store.hoverStore.hoveredCaseIds = [];
               }}
-              hoverColor={store.hoverStore.hoverColor}
+              hoverColor={store.hoverStore.smallHoverColor}
               key={`dumbbell-${idx}`}
             />,
           );

--- a/frontend/src/Components/Charts/DumbbellChart/SingleDumbbell.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/SingleDumbbell.tsx
@@ -46,7 +46,7 @@ function SingleDumbbell({
           x={xVal - 1}
           y={yValCalculation}
           height={rectHeight}
-          isselected={isSelectSet}
+          isSelected={isSelectSet}
           display={showGap ? undefined : 'none'}
           isHovered={isHovered}
           hoverColor={hoverColor}
@@ -55,7 +55,7 @@ function SingleDumbbell({
           cx={xVal}
           cy={circleYValStart}
           isSelectSet={isSelectSet}
-          ispreop
+          isPreop
           display={showPreop ? undefined : 'none'}
           isHovered={isHovered}
           hoverColor={hoverColor}
@@ -64,7 +64,7 @@ function SingleDumbbell({
           cx={xVal}
           cy={circleYValEnd}
           isSelectSet={isSelectSet}
-          ispreop={false}
+          isPreop={false}
           display={showPostop ? undefined : 'none'}
           isHovered={isHovered}
           hoverColor={hoverColor}

--- a/frontend/src/Components/Charts/DumbbellChart/SingleDumbbell.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/SingleDumbbell.tsx
@@ -13,7 +13,7 @@ type Props = {
     showGap: boolean;
     circleYValStart: number;
     circleYValEnd: number;
-    isHovered: boolean;
+    hovered: boolean;
     onMouseEnter: () => void;
     onMouseLeave: () => void;
     hoverColor: string;
@@ -28,7 +28,7 @@ function SingleDumbbell({
   showPreop,
   circleYValStart,
   circleYValEnd,
-  isHovered,
+  hovered,
   onMouseEnter,
   onMouseLeave,
   hoverColor,
@@ -46,9 +46,9 @@ function SingleDumbbell({
           x={xVal - 1}
           y={yValCalculation}
           height={rectHeight}
-          isSelected={isSelectSet}
+          selected={isSelectSet}
           display={showGap ? undefined : 'none'}
-          isHovered={isHovered}
+          hovered={hovered}
           hoverColor={hoverColor}
         />
         <DumbbellCircle
@@ -57,7 +57,7 @@ function SingleDumbbell({
           isSelectSet={isSelectSet}
           isPreop
           display={showPreop ? undefined : 'none'}
-          isHovered={isHovered}
+          hovered={hovered}
           hoverColor={hoverColor}
         />
         <DumbbellCircle
@@ -66,7 +66,7 @@ function SingleDumbbell({
           isSelectSet={isSelectSet}
           isPreop={false}
           display={showPostop ? undefined : 'none'}
-          isHovered={isHovered}
+          hovered={hovered}
           hoverColor={hoverColor}
         />
       </g>

--- a/frontend/src/Components/Charts/DumbbellChart/SingleDumbbell.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/SingleDumbbell.tsx
@@ -13,10 +13,25 @@ type Props = {
     showGap: boolean;
     circleYValStart: number;
     circleYValEnd: number;
+    isHovered: boolean;
+    onMouseEnter: () => void;
+    onMouseLeave: () => void;
+    hoverColor: string;
 };
 
 function SingleDumbbell({
-  xVal, dataPoint, isSelectSet, showGap, showPostop, showPreop, circleYValStart, circleYValEnd,
+  xVal,
+  dataPoint,
+  isSelectSet,
+  showGap,
+  showPostop,
+  showPreop,
+  circleYValStart,
+  circleYValEnd,
+  isHovered,
+  onMouseEnter,
+  onMouseLeave,
+  hoverColor,
 }: Props) {
   const yValCalculation = circleYValStart > circleYValEnd ? circleYValEnd : circleYValStart;
   const rectHeight = Math.abs(circleYValStart - circleYValEnd);
@@ -26,13 +41,15 @@ function SingleDumbbell({
       arrow
       placement="top"
     >
-      <g>
+      <g onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         <DumbbellRect
           x={xVal - 1}
           y={yValCalculation}
           height={rectHeight}
           isselected={isSelectSet}
           display={showGap ? undefined : 'none'}
+          isHovered={isHovered}
+          hoverColor={hoverColor}
         />
         <DumbbellCircle
           cx={xVal}
@@ -40,15 +57,17 @@ function SingleDumbbell({
           isSelectSet={isSelectSet}
           ispreop
           display={showPreop ? undefined : 'none'}
+          isHovered={isHovered}
+          hoverColor={hoverColor}
         />
         <DumbbellCircle
-          cx={
-                        xVal
-                    }
+          cx={xVal}
           cy={circleYValEnd}
           isSelectSet={isSelectSet}
           ispreop={false}
           display={showPostop ? undefined : 'none'}
+          isHovered={isHovered}
+          hoverColor={hoverColor}
         />
       </g>
     </Tooltip>

--- a/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
@@ -16,7 +16,7 @@ import { AcronymDictionary, BloodComponent, HemoOption } from '../../../Presets/
 import CustomizedAxisBand from '../ChartAccessories/CustomizedAxisBand';
 
 interface DotProps {
-  isselected: boolean;
+  isSelected: boolean;
   isbrushed: boolean;
   isHovered: boolean;
   hoverColor: string;
@@ -24,11 +24,11 @@ interface DotProps {
 
 const ScatterDot = styled('circle')<DotProps>`
   r: 4px;
-  opacity: ${(props) => (props.isHovered || props.isselected ? 1 : 0.5)};
+  opacity: ${(props) => (props.isHovered || props.isSelected ? 1 : 0.5)};
   stroke-width: 2px;
   fill: ${(props) => (props.isHovered
     ? props.hoverColor
-    : props.isbrushed || props.isselected
+    : props.isbrushed || props.isSelected
       ? highlightOrange
       : basicGray)};
 `;
@@ -224,7 +224,7 @@ function ScatterPlot({
             key={`dot-${idx}`}
             cx={cx}
             cy={cy}
-            isselected={isSelectSet}
+            isSelected={isSelectSet}
             isbrushed={isBrushed || false}
             isHovered={isHovered}
             hoverColor={hoverStore.smallHoverColor}
@@ -238,7 +238,7 @@ function ScatterPlot({
             key={`dot-${idx}`}
             cx={cx}
             cy={cy}
-            isselected={isSelectSet}
+            isSelected={isSelectSet}
             isbrushed={isBrushed || false}
             isHovered={isHovered}
             hoverColor={hoverStore.smallHoverColor}

--- a/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
@@ -63,6 +63,7 @@ function ScatterPlot({
   const [brushLoc, updateBrushLoc] = useState<[[number, number], [number, number]] | null>(null);
   const [isFirstRender, updateIsFirstRender] = useState(true);
   const [brushedCaseList, updatebrushedCaseList] = useState<number[]>([]);
+  const [hoveredColumn, setHoveredColumn] = useState<number | null>(null);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const updateBrush = (e: any) => {
@@ -277,6 +278,22 @@ function ScatterPlot({
     return unselectedPatients.concat(selectedPatients).concat(lineSet);
   };
 
+  // Add a new handler that updates both the local hoveredColumn state and the store.
+  const handleColumnHover = (columnIndex: number | null) => {
+    setHoveredColumn(columnIndex);
+    if (columnIndex !== null) {
+      // Filter the data using dp.xVal because the column represents the x-axis category.
+      const pointsInColumn = data.filter((dp: ScatterDataPoint) => dp.xVal === columnIndex);
+      // Update the hover store with all case IDs in that column
+      store.hoverStore.hoveredCaseIds = pointsInColumn.map(
+        (dp: ScatterDataPoint) => dp.case.CASE_ID,
+      );
+    } else {
+      // Clear hovered cases when no column is hovered.
+      store.hoverStore.hoveredCaseIds = [];
+    }
+  };
+
   return (
     <>
       <g className="chart-comp">
@@ -289,18 +306,17 @@ function ScatterPlot({
           y={0}
           className="highlight-label"
         />
-        <g className="brush-layer" />
-        {generateScatterDots()}
       </g>
       <g className="axes">
         <g className="y-axis" />
         <g className="x-axis" transform={`translate(0 ,${height - currentOffset.bottom} )`}>
-          {xAxisVar !== 'CELL_SAVER_ML' ? <CustomizedAxisBand scalePadding={scalePadding} scaleDomain={JSON.stringify(xAxisScale().domain())} scaleRange={JSON.stringify(xAxisScale().range())} /> : null}
+          {xAxisVar !== 'CELL_SAVER_ML' ? <CustomizedAxisBand scalePadding={scalePadding} scaleDomain={JSON.stringify(xAxisScale().domain())} scaleRange={JSON.stringify(xAxisScale().range())} chartHeight={height - currentOffset.bottom - currentOffset.top} hoveredColumn={hoveredColumn} onColumnHover={handleColumnHover} /> : null}
         </g>
         <text className="x-label" />
         <text className="y-label" />
       </g>
-
+      <g className="brush-layer" />
+      {generateScatterDots()}
     </>
   );
 }

--- a/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
@@ -16,19 +16,19 @@ import { AcronymDictionary, BloodComponent, HemoOption } from '../../../Presets/
 import CustomizedAxisBand from '../ChartAccessories/CustomizedAxisBand';
 
 interface DotProps {
-  isSelected: boolean;
-  isbrushed: boolean;
-  isHovered: boolean;
+  selected: boolean;
+  brushed: boolean;
+  hovered: boolean;
   hoverColor: string;
 }
 
 const ScatterDot = styled('circle')<DotProps>`
   r: 4px;
-  opacity: ${(props) => (props.isHovered || props.isSelected ? 1 : 0.5)};
+  opacity: ${(props) => (props.hovered || props.selected ? 1 : 0.5)};
   stroke-width: 2px;
-  fill: ${(props) => (props.isHovered
+  fill: ${(props) => (props.hovered
     ? props.hoverColor
-    : props.isbrushed || props.isSelected
+    : props.brushed || props.selected
       ? highlightOrange
       : basicGray)};
 `;
@@ -39,16 +39,16 @@ const StatisticalLine = styled('line')`
 `;
 
 type Props = {
-    xAxisVar: BloodComponent;
-    yAxisVar: HemoOption;
-    width: number;
-    height: number;
-    data: ScatterDataPoint[];
-    svg: React.RefObject<SVGSVGElement>;
-    yMin: number;
-    yMax: number;
-    xMin: number;
-    xMax: number;
+  xAxisVar: BloodComponent;
+  yAxisVar: HemoOption;
+  width: number;
+  height: number;
+  data: ScatterDataPoint[];
+  svg: React.RefObject<SVGSVGElement>;
+  yMin: number;
+  yMax: number;
+  xMin: number;
+  xMax: number;
 };
 
 function ScatterPlot({
@@ -208,7 +208,7 @@ function ScatterPlot({
     data.forEach((dataPoint, idx) => {
       const cx = xAxisVar === 'CELL_SAVER_ML' ? ((xAxisScale()(dataPoint.xVal)) || 0) : ((xAxisScale()(dataPoint.xVal) || 0) + dataPoint.randomFactor * xAxisScale().bandwidth());
       // Check if the data point is hovered
-      const isHovered = hoverStore.hoveredCaseIds.includes(dataPoint.case.CASE_ID);
+      const hovered = hoverStore.hoveredCaseIds.includes(dataPoint.case.CASE_ID);
       if (medianSet[dataPoint.xVal]) {
         medianSet[dataPoint.xVal].push(dataPoint.yVal);
       } else {
@@ -216,17 +216,17 @@ function ScatterPlot({
       }
       const cy = yAxisScale()(dataPoint.yVal);
       const isSelectSet = decideIfSelectSet(dataPoint);
-      const isBrushed = brushedSet.has(dataPoint.case.CASE_ID);
+      const brushed = brushedSet.has(dataPoint.case.CASE_ID);
 
-      if (isBrushed || isSelectSet) {
+      if (brushed || isSelectSet) {
         selectedPatients.push(
           <ScatterDot
             key={`dot-${idx}`}
             cx={cx}
             cy={cy}
-            isSelected={isSelectSet}
-            isbrushed={isBrushed || false}
-            isHovered={isHovered}
+            selected={isSelectSet}
+            brushed={brushed || false}
+            hovered={hovered}
             hoverColor={hoverStore.smallHoverColor}
             onMouseEnter={() => { hoverStore.hoveredCaseIds = [dataPoint.case.CASE_ID]; }}
             onMouseLeave={() => { hoverStore.hoveredCaseIds = []; }}
@@ -238,9 +238,9 @@ function ScatterPlot({
             key={`dot-${idx}`}
             cx={cx}
             cy={cy}
-            isSelected={isSelectSet}
-            isbrushed={isBrushed || false}
-            isHovered={isHovered}
+            selected={isSelectSet}
+            brushed={brushed || false}
+            hovered={hovered}
             hoverColor={hoverStore.smallHoverColor}
             onMouseEnter={() => { hoverStore.hoveredCaseIds = [dataPoint.case.CASE_ID]; }}
             onMouseLeave={() => { hoverStore.hoveredCaseIds = []; }}

--- a/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
@@ -63,7 +63,6 @@ function ScatterPlot({
   const [brushLoc, updateBrushLoc] = useState<[[number, number], [number, number]] | null>(null);
   const [isFirstRender, updateIsFirstRender] = useState(true);
   const [brushedCaseList, updatebrushedCaseList] = useState<number[]>([]);
-  const [hoveredColumn, setHoveredColumn] = useState<number | null>(null);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const updateBrush = (e: any) => {
@@ -278,22 +277,6 @@ function ScatterPlot({
     return unselectedPatients.concat(selectedPatients).concat(lineSet);
   };
 
-  // Add a new handler that updates both the local hoveredColumn state and the store.
-  const handleColumnHover = (columnIndex: number | null) => {
-    setHoveredColumn(columnIndex);
-    if (columnIndex !== null) {
-      // Filter the data using dp.xVal because the column represents the x-axis category.
-      const pointsInColumn = data.filter((dp: ScatterDataPoint) => dp.xVal === columnIndex);
-      // Update the hover store with all case IDs in that column
-      store.hoverStore.hoveredCaseIds = pointsInColumn.map(
-        (dp: ScatterDataPoint) => dp.case.CASE_ID,
-      );
-    } else {
-      // Clear hovered cases when no column is hovered.
-      store.hoverStore.hoveredCaseIds = [];
-    }
-  };
-
   return (
     <>
       <g className="chart-comp">
@@ -310,7 +293,7 @@ function ScatterPlot({
       <g className="axes">
         <g className="y-axis" />
         <g className="x-axis" transform={`translate(0 ,${height - currentOffset.bottom} )`}>
-          {xAxisVar !== 'CELL_SAVER_ML' ? <CustomizedAxisBand scalePadding={scalePadding} scaleDomain={JSON.stringify(xAxisScale().domain())} scaleRange={JSON.stringify(xAxisScale().range())} chartHeight={height - currentOffset.bottom - currentOffset.top} hoveredColumn={hoveredColumn} onColumnHover={handleColumnHover} /> : null}
+          {xAxisVar !== 'CELL_SAVER_ML' ? <CustomizedAxisBand scalePadding={scalePadding} scaleDomain={JSON.stringify(xAxisScale().domain())} scaleRange={JSON.stringify(xAxisScale().range())} chartHeight={height - currentOffset.bottom - currentOffset.top} data={data} /> : null}
         </g>
         <text className="x-label" />
         <text className="y-label" />

--- a/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
@@ -229,6 +229,8 @@ function ScatterPlot({
             isselected={isSelectSet}
             isbrushed={isBrushed || false}
             isHovered={isHovered}
+            onMouseEnter={() => { hoverStore.hoveredCaseIds = [dataPoint.case.CASE_ID]; }}
+            onMouseLeave={() => { hoverStore.hoveredCaseIds = []; }}
           />,
         );
       } else {
@@ -240,6 +242,8 @@ function ScatterPlot({
             isselected={isSelectSet}
             isbrushed={isBrushed || false}
             isHovered={isHovered}
+            onMouseEnter={() => { hoverStore.hoveredCaseIds = [dataPoint.case.CASE_ID]; }}
+            onMouseLeave={() => { hoverStore.hoveredCaseIds = []; }}
           />,
 
         );
@@ -286,9 +290,8 @@ function ScatterPlot({
           y={0}
           className="highlight-label"
         />
-
-        {generateScatterDots()}
         <g className="brush-layer" />
+        {generateScatterDots()}
       </g>
       <g className="axes">
         <g className="y-axis" />

--- a/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
@@ -19,21 +19,18 @@ interface DotProps {
   isselected: boolean;
   isbrushed: boolean;
   isHovered: boolean;
+  hoverColor: string;
 }
 
 const ScatterDot = styled('circle')<DotProps>`
   r: 4px;
   opacity: ${(props) => (props.isHovered || props.isselected ? 1 : 0.5)};
   stroke-width: 2px;
-  fill: ${(props) => {
-    const store = useContext(Store);
-    const { hoverStore } = store;
-    return props.isHovered
-      ? hoverStore.hoverColor
-      : props.isbrushed || props.isselected
-        ? highlightOrange
-        : basicGray;
-  }};
+  fill: ${(props) => (props.isHovered
+    ? props.hoverColor
+    : props.isbrushed || props.isselected
+      ? highlightOrange
+      : basicGray)};
 `;
 
 const StatisticalLine = styled('line')`
@@ -229,6 +226,7 @@ function ScatterPlot({
             isselected={isSelectSet}
             isbrushed={isBrushed || false}
             isHovered={isHovered}
+            hoverColor={hoverStore.smallHoverColor}
             onMouseEnter={() => { hoverStore.hoveredCaseIds = [dataPoint.case.CASE_ID]; }}
             onMouseLeave={() => { hoverStore.hoveredCaseIds = []; }}
           />,
@@ -242,6 +240,7 @@ function ScatterPlot({
             isselected={isSelectSet}
             isbrushed={isBrushed || false}
             isHovered={isHovered}
+            hoverColor={hoverStore.smallHoverColor}
             onMouseEnter={() => { hoverStore.hoveredCaseIds = [dataPoint.case.CASE_ID]; }}
             onMouseLeave={() => { hoverStore.hoveredCaseIds = []; }}
           />,

--- a/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/Components/Charts/ScatterPlot/ScatterPlot.tsx
@@ -18,12 +18,22 @@ import CustomizedAxisBand from '../ChartAccessories/CustomizedAxisBand';
 interface DotProps {
   isselected: boolean;
   isbrushed: boolean;
+  isHovered: boolean;
 }
-const ScatterDot = styled('circle') <DotProps>`
-r:4px;
-opacity:${(props) => (props.isselected ? 1 : 0.5)};
-stroke-width:2px;
-fill:${(props) => (props.isbrushed || props.isselected ? highlightOrange : basicGray)};
+
+const ScatterDot = styled('circle')<DotProps>`
+  r: 4px;
+  opacity: ${(props) => (props.isHovered || props.isselected ? 1 : 0.5)};
+  stroke-width: 2px;
+  fill: ${(props) => {
+    const store = useContext(Store);
+    const { hoverStore } = store;
+    return props.isHovered
+      ? hoverStore.hoverColor
+      : props.isbrushed || props.isselected
+        ? highlightOrange
+        : basicGray;
+  }};
 `;
 
 const StatisticalLine = styled('line')`
@@ -50,6 +60,7 @@ function ScatterPlot({
   const scalePadding = 0.2;
   const currentOffset = OffsetDict.minimum;
   const store = useContext(Store);
+  const { hoverStore } = store;
   const { currentBrushedPatientGroup, currentSelectSet } = store.provenanceState;
   const svgSelection = select(svg.current);
   const [brushLoc, updateBrushLoc] = useState<[[number, number], [number, number]] | null>(null);
@@ -198,7 +209,8 @@ function ScatterPlot({
     const medianSet: Record<string, number[]> = {};
     data.forEach((dataPoint, idx) => {
       const cx = xAxisVar === 'CELL_SAVER_ML' ? ((xAxisScale()(dataPoint.xVal)) || 0) : ((xAxisScale()(dataPoint.xVal) || 0) + dataPoint.randomFactor * xAxisScale().bandwidth());
-
+      // Check if the data point is hovered
+      const isHovered = hoverStore.hoveredCaseIds.includes(dataPoint.case.CASE_ID);
       if (medianSet[dataPoint.xVal]) {
         medianSet[dataPoint.xVal].push(dataPoint.yVal);
       } else {
@@ -216,6 +228,7 @@ function ScatterPlot({
             cy={cy}
             isselected={isSelectSet}
             isbrushed={isBrushed || false}
+            isHovered={isHovered}
           />,
         );
       } else {
@@ -226,6 +239,7 @@ function ScatterPlot({
             cy={cy}
             isselected={isSelectSet}
             isbrushed={isBrushed || false}
+            isHovered={isHovered}
           />,
 
         );

--- a/frontend/src/Components/Utilities/LeftToolBox/SurgeryListViewer.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/SurgeryListViewer.tsx
@@ -102,7 +102,7 @@ function SurgeryListViewer({ surgeryList, maxCaseCount }: Props) {
                   expandedList={expandedList}
                   setExpandedList={setExpandedList}
                   listItem={listItem}
-                  isSelected
+                  selected
                   isSubSurgery={false}
                   highlighted={!findIfSelectedSubProcedureExist(listItem.procedureName)}
                   caseScaleDomain={JSON.stringify(caseScale().domain())}
@@ -116,7 +116,7 @@ function SurgeryListViewer({ surgeryList, maxCaseCount }: Props) {
                     expandedList={expandedList}
                     setExpandedList={setExpandedList}
                     listItem={subItem}
-                    isSelected={findIfSubProcedureSelected(subItem.procedureName, listItem.procedureName)}
+                    selected={findIfSubProcedureSelected(subItem.procedureName, listItem.procedureName)}
                     isSubSurgery
                     highlighted={findIfSubProcedureSelected(subItem.procedureName, listItem.procedureName)}
                     parentSurgery={listItem}
@@ -132,7 +132,7 @@ function SurgeryListViewer({ surgeryList, maxCaseCount }: Props) {
                   expandedList={expandedList}
                   setExpandedList={setExpandedList}
                   listItem={listItem}
-                  isSelected
+                  selected
                   isSubSurgery={false}
                   highlighted
                   caseScaleDomain={JSON.stringify(caseScale().domain())}
@@ -148,7 +148,7 @@ function SurgeryListViewer({ surgeryList, maxCaseCount }: Props) {
                   listItem={listItem}
                   expandedList={expandedList}
                   setExpandedList={setExpandedList}
-                  isSelected={false}
+                  selected={false}
                   isSubSurgery={false}
                   highlighted={false}
                   caseScaleDomain={JSON.stringify(caseScale().domain())}
@@ -159,7 +159,7 @@ function SurgeryListViewer({ surgeryList, maxCaseCount }: Props) {
                   <SurgeryRow
                     key={subItem.procedureName}
                     listItem={subItem}
-                    isSelected={false}
+                    selected={false}
                     expandedList={expandedList}
                     setExpandedList={setExpandedList}
                     isSubSurgery
@@ -176,7 +176,7 @@ function SurgeryListViewer({ surgeryList, maxCaseCount }: Props) {
                 listItem={listItem}
                 expandedList={expandedList}
                 setExpandedList={setExpandedList}
-                isSelected={false}
+                selected={false}
                 isSubSurgery={false}
                 highlighted={false}
                 caseScaleDomain={JSON.stringify(caseScale().domain())}

--- a/frontend/src/Components/Utilities/LeftToolBox/SurgeryRow.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/SurgeryRow.tsx
@@ -14,7 +14,7 @@ function isOverflown(element: Element) {
 
 type Props = {
     listItem: ProcedureEntry;
-    isSelected: boolean;
+    selected: boolean;
     isSubSurgery: boolean;
     highlighted: boolean;
     caseScaleDomain: string;
@@ -25,7 +25,7 @@ type Props = {
     setExpandedList: Dispatch<SetStateAction<string[]>>;
 };
 function SurgeryRow({
-  listItem, width, isSelected, expandedList, setExpandedList, isSubSurgery, highlighted, caseScaleDomain, caseScaleRange, parentSurgery,
+  listItem, width, selected, expandedList, setExpandedList, isSubSurgery, highlighted, caseScaleDomain, caseScaleRange, parentSurgery,
 }: Props) {
   const [showSVG, setShowSVG] = useState(true);
   const spanRef = useRef(null);
@@ -49,10 +49,10 @@ function SurgeryRow({
   return (
     <SurgeryListComp
       key={`${isSubSurgery && parentSurgery ? `${parentSurgery}-` : ''}${listItem.procedureName}`}
-      isSelected={highlighted}
+      selected={highlighted}
     >
 
-      <SurgeryDiv ref={spanRef} onClick={() => { store.selectionStore.updateProcedureSelection(listItem, isSelected, isSubSurgery ? parentSurgery : undefined); }}>
+      <SurgeryDiv ref={spanRef} onClick={() => { store.selectionStore.updateProcedureSelection(listItem, selected, isSubSurgery ? parentSurgery : undefined); }}>
         {isSubSurgery
           ? (
             <>

--- a/frontend/src/Interfaces/HoverStore.ts
+++ b/frontend/src/Interfaces/HoverStore.ts
@@ -31,18 +31,10 @@ export class HoverStore {
     makeAutoObservable(this);
   }
 
-  /**
-   * Getter for the hoveredCaseIds
-   * @returns {number[]} The list of hovered case IDs
-   */
   get hoveredCaseIds() {
     return this._hoveredCaseIds;
   }
 
-  /**
-   * Setter for the hoveredCaseIds
-   * @param {number[]} ids - The list of hovered case IDs
-   */
   set hoveredCaseIds(ids: number[]) {
     this._hoveredCaseIds = structuredClone(ids);
   }

--- a/frontend/src/Interfaces/HoverStore.ts
+++ b/frontend/src/Interfaces/HoverStore.ts
@@ -2,12 +2,6 @@ import { makeAutoObservable } from 'mobx';
 // eslint-disable-next-line import/no-cycle
 import { RootStore } from './Store';
 
-/**
- * @typedef {Object} HoverStore
- * @property {number[]} hoveredCaseIds - The list of hovered case IDs
- * @property {string} hoverColor - The color of the hover
- * @property {RootStore} rootStore - The root store
- */
 export class HoverStore {
   rootStore: RootStore;
 

--- a/frontend/src/Interfaces/HoverStore.ts
+++ b/frontend/src/Interfaces/HoverStore.ts
@@ -1,0 +1,49 @@
+import { makeAutoObservable } from 'mobx';
+// eslint-disable-next-line import/no-cycle
+import { RootStore } from './Store';
+
+/**
+ * @typedef {Object} HoverStore
+ * @property {number[]} hoveredCaseIds - The list of hovered case IDs
+ * @property {string} hoverColor - The color of the hover
+ * @property {RootStore} rootStore - The root store
+ */
+export class HoverStore {
+  rootStore: RootStore;
+
+  // Currently hovered case IDs
+  private _hoveredCaseIds: number[];
+
+  // Color of the hover
+  public readonly hoverColor: string;
+
+  // Extends the root store
+  constructor(rootStore: RootStore) {
+    this.rootStore = rootStore;
+
+    // Currently hovered case IDs
+    this._hoveredCaseIds = [];
+
+    // Color of the hover
+    this.hoverColor = '#FFE8BE';
+
+    // Make the store observable
+    makeAutoObservable(this);
+  }
+
+  /**
+   * Getter for the hoveredCaseIds
+   * @returns {number[]} The list of hovered case IDs
+   */
+  get hoveredCaseIds() {
+    return this._hoveredCaseIds;
+  }
+
+  /**
+   * Setter for the hoveredCaseIds
+   * @param {number[]} ids - The list of hovered case IDs
+   */
+  set hoveredCaseIds(ids: number[]) {
+    this._hoveredCaseIds = ids;
+  }
+}

--- a/frontend/src/Interfaces/HoverStore.ts
+++ b/frontend/src/Interfaces/HoverStore.ts
@@ -14,8 +14,11 @@ export class HoverStore {
   // Currently hovered case IDs
   private _hoveredCaseIds: number[];
 
-  // Color of the hover
-  public readonly hoverColor: string;
+  // Color of the smaller mark hover
+  public readonly smallHoverColor: string;
+
+  // Color of a larger background hover
+  public readonly backgroundHoverColor: string;
 
   // Extends the root store
   constructor(rootStore: RootStore) {
@@ -25,7 +28,10 @@ export class HoverStore {
     this._hoveredCaseIds = [];
 
     // Color of the hover
-    this.hoverColor = '#FFE8BE';
+    this.smallHoverColor = '#FFCF76';
+
+    // Color of the hover
+    this.backgroundHoverColor = '#FFE8BE';
 
     // Make the store observable
     makeAutoObservable(this);

--- a/frontend/src/Interfaces/HoverStore.ts
+++ b/frontend/src/Interfaces/HoverStore.ts
@@ -50,6 +50,6 @@ export class HoverStore {
    * @param {number[]} ids - The list of hovered case IDs
    */
   set hoveredCaseIds(ids: number[]) {
-    this._hoveredCaseIds = ids;
+    this._hoveredCaseIds = structuredClone(ids);
   }
 }

--- a/frontend/src/Interfaces/Store.ts
+++ b/frontend/src/Interfaces/Store.ts
@@ -11,6 +11,7 @@ import { ActionEvents } from './Types/EventTypes';
 import { ApplicationState } from './Types/StateTypes';
 import { SingleCasePoint } from './Types/DataTypes';
 import { SurgeryUrgencyArray } from '../Presets/DataDict';
+import { HoverStore } from './HoverStore';
 
 export class RootStore {
   provenance: Provenance<ApplicationState, ActionEvents>;
@@ -18,6 +19,8 @@ export class RootStore {
   configStore: ProjectConfigStore;
 
   selectionStore: SelectionStore;
+
+  hoverStore: HoverStore;
 
   chartStore: ChartStore;
 
@@ -35,6 +38,7 @@ export class RootStore {
     this.configStore = new ProjectConfigStore(this);
     this.chartStore = new ChartStore(this);
     this.selectionStore = new SelectionStore(this);
+    this.hoverStore = new HoverStore(this);
 
     this._allCases = [];
 

--- a/frontend/src/Presets/StyledComponents.ts
+++ b/frontend/src/Presets/StyledComponents.ts
@@ -45,11 +45,11 @@ export const ChartAccessoryDiv = styled.div({
 });
 
 interface SurgeryListProps {
-    isSelected: boolean;
+    selected: boolean;
 }
 
 export const SurgeryListComp = styled('tr') <SurgeryListProps>`
-  background:${(props) => (props.isSelected ? '#ecbe8d' : 'none')};
+  background:${(props) => (props.selected ? '#ecbe8d' : 'none')};
   cursor: pointer;
   &:hover{
     background:#faeee1;

--- a/frontend/src/Presets/StyledSVGComponents.ts
+++ b/frontend/src/Presets/StyledSVGComponents.ts
@@ -53,44 +53,50 @@ export const HeatMapDividerLine = styled('line') <HeatMapDivideProp>`
 
 interface DotProps {
   isSelectSet: boolean;
-  ispreop: boolean;
+  isPreop: boolean;
   isHovered: boolean;
   hoverColor: string;
 }
 interface RectProps {
-  isselected: boolean;
+  isSelected: boolean;
   isHovered: boolean;
   hoverColor: string;
 }
 
 interface AverageLineProps {
-  ispreop: boolean;
+  isPreop: boolean;
 }
 
 export const DumbbellCircle = styled('circle')<DotProps>`
-     r:4px;
-     fill: ${(props) => (props.isHovered
-    ? props.hoverColor
-    : props.isSelectSet
-      ? highlightOrange
-      : props.ispreop
-        ? preopColor
-        : postopColor)};
-     opacity: ${(props) => (props.isSelectSet || props.isHovered ? 1 : 0.8)};
-   `;
+  r: 4px;
+  fill: ${(props) => {
+    if (props.isHovered) {
+      return props.hoverColor;
+    }
+    if (props.isSelectSet) {
+      return highlightOrange;
+    }
+    return props.isPreop ? preopColor : postopColor;
+  }};
+  opacity: ${(props) => (props.isSelectSet || props.isHovered ? 1 : 0.8)};
+`;
 
 export const DumbbellRect = styled('rect')<RectProps>`
-   width:1.5px;
-   opacity: ${(props) => (props.isselected || props.isHovered ? 1 : 0.5)};
-   fill: ${(props) => (props.isHovered
-    ? props.hoverColor
-    : props.isselected
-      ? highlightOrange
-      : basicGray)};
+  width:1.5px;
+  opacity: ${(props) => (props.isSelected || props.isHovered ? 1 : 0.5)};
+  fill: ${(props) => {
+    if (props.isHovered) {
+      return props.hoverColor;
+    }
+    if (props.isSelected) {
+      return highlightOrange;
+    }
+    return basicGray;
+  }};
  `;
 
 export const DumbbellLine = styled('line') < AverageLineProps>`
-    stroke: ${(props) => (props.ispreop ? preopColor : postopColor)};
+    stroke: ${(props) => (props.isPreop ? preopColor : postopColor)};
     stroke-width:3px
     `;
 

--- a/frontend/src/Presets/StyledSVGComponents.ts
+++ b/frontend/src/Presets/StyledSVGComponents.ts
@@ -54,26 +54,40 @@ export const HeatMapDividerLine = styled('line') <HeatMapDivideProp>`
 interface DotProps {
   isSelectSet: boolean;
   ispreop: boolean;
+  isHovered: boolean;
+  hoverColor: string;
 }
 interface RectProps {
   isselected: boolean;
+  isHovered: boolean;
+  hoverColor: string;
 }
 
 interface AverageLineProps {
   ispreop: boolean;
 }
 
-export const DumbbellCircle = styled('circle') <DotProps>`
-  r:4px;
-  fill: ${(props) => (props.isSelectSet ? highlightOrange : props.ispreop ? preopColor : postopColor)};
-  opacity:${(props) => (props.isSelectSet ? 1 : 0.8)};
-`;
+export const DumbbellCircle = styled('circle')<DotProps>`
+     r:4px;
+     fill: ${(props) => (props.isHovered
+    ? props.hoverColor
+    : props.isSelectSet
+      ? highlightOrange
+      : props.ispreop
+        ? preopColor
+        : postopColor)};
+     opacity: ${(props) => (props.isSelectSet || props.isHovered ? 1 : 0.8)};
+   `;
 
-export const DumbbellRect = styled('rect') <RectProps>`
- width:1.5px;
- opacity:${(props) => (props.isselected ? 1 : 0.5)};
- fill: ${(props) => (props.isselected ? highlightOrange : basicGray)};
-`;
+export const DumbbellRect = styled('rect')<RectProps>`
+   width:1.5px;
+   opacity: ${(props) => (props.isselected || props.isHovered ? 1 : 0.5)};
+   fill: ${(props) => (props.isHovered
+    ? props.hoverColor
+    : props.isselected
+      ? highlightOrange
+      : basicGray)};
+ `;
 
 export const DumbbellLine = styled('line') < AverageLineProps>`
     stroke: ${(props) => (props.ispreop ? preopColor : postopColor)};
@@ -107,7 +121,6 @@ interface CustomAxisColumnBackgroundProps {
 export const CustomAxisColumnBackground = styled('rect')<CustomAxisColumnBackgroundProps>`
     height: ${({ chartHeight }) => chartHeight}px;
     y: -${({ chartHeight }) => chartHeight}px;
-    opacity: 0.05;
 `;
 
 export const CustomAxisLineBox = styled('rect')`

--- a/frontend/src/Presets/StyledSVGComponents.ts
+++ b/frontend/src/Presets/StyledSVGComponents.ts
@@ -69,6 +69,7 @@ interface AverageLineProps {
 
 export const DumbbellCircle = styled('circle')<DotProps>`
   r: 4px;
+  opacity: ${(props) => (props.isSelectSet || props.isHovered ? 1 : 0.8)};
   fill: ${(props) => {
     if (props.isHovered) {
       return props.hoverColor;
@@ -78,11 +79,10 @@ export const DumbbellCircle = styled('circle')<DotProps>`
     }
     return props.isPreop ? preopColor : postopColor;
   }};
-  opacity: ${(props) => (props.isSelectSet || props.isHovered ? 1 : 0.8)};
 `;
 
 export const DumbbellRect = styled('rect')<RectProps>`
-  width:1.5px;
+  width: 1.5px;
   opacity: ${(props) => (props.isSelected || props.isHovered ? 1 : 0.5)};
   fill: ${(props) => {
     if (props.isHovered) {

--- a/frontend/src/Presets/StyledSVGComponents.ts
+++ b/frontend/src/Presets/StyledSVGComponents.ts
@@ -54,12 +54,12 @@ export const HeatMapDividerLine = styled('line') <HeatMapDivideProp>`
 interface DotProps {
   isSelectSet: boolean;
   isPreop: boolean;
-  isHovered: boolean;
+  hovered: boolean;
   hoverColor: string;
 }
 interface RectProps {
-  isSelected: boolean;
-  isHovered: boolean;
+  selected: boolean;
+  hovered: boolean;
   hoverColor: string;
 }
 
@@ -69,9 +69,9 @@ interface AverageLineProps {
 
 export const DumbbellCircle = styled('circle')<DotProps>`
   r: 4px;
-  opacity: ${(props) => (props.isSelectSet || props.isHovered ? 1 : 0.8)};
+  opacity: ${(props) => (props.isSelectSet || props.hovered ? 1 : 0.8)};
   fill: ${(props) => {
-    if (props.isHovered) {
+    if (props.hovered) {
       return props.hoverColor;
     }
     if (props.isSelectSet) {
@@ -83,12 +83,12 @@ export const DumbbellCircle = styled('circle')<DotProps>`
 
 export const DumbbellRect = styled('rect')<RectProps>`
   width: 1.5px;
-  opacity: ${(props) => (props.isSelected || props.isHovered ? 1 : 0.5)};
+  opacity: ${(props) => (props.selected || props.hovered ? 1 : 0.5)};
   fill: ${(props) => {
-    if (props.isHovered) {
+    if (props.hovered) {
       return props.hoverColor;
     }
-    if (props.isSelected) {
+    if (props.selected) {
       return highlightOrange;
     }
     return basicGray;


### PR DESCRIPTION
### Does this PR close any open issues?

Does not end #327 quite yet, because we want to apply highlighting to _all charts._
This PR just for dumbbell charts + scatter plots.

### Give a longer description of what this PR addresses and why it's needed

On hover, dumbbell charts and scatter plots have cross-highlighting between them.
- Highlighting (hovering) a _column_ or _individual datapoint (case)_ in either the dumbbell chart or the scatter plot, highlights all corresponding points (_cases_) in the other chart.

**Caveat:** To highlight a column in a scatterplot, hover over its column label.

### Provide pictures/videos of the behavior before and after these changes (optional)

https://github.com/user-attachments/assets/4c5e05e5-19e2-48ea-bc63-53ba9c6a23ae

### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [X] ...
