### PR TITLE
Heatmap Hovering Transparency

### DIFF
--- a/frontend/src/Components/Charts/HeatMap/HeatMap.tsx
+++ b/frontend/src/Components/Charts/HeatMap/HeatMap.tsx
@@ -109,9 +109,9 @@ function HeatMap({
                   {/** Background Hover Row Rectangle */}
                   <rect
                     x={0}
-                    y={0}
+                    y={-1}
                     width={dimensionWidth}
-                    height={rowHeight}
+                    height={rowHeight + 2}
                     fill={isHovered ? hoverStore.backgroundHoverColor : 'transparent'}
                   />
                   <SingleHeatRow

--- a/frontend/src/Components/Charts/HeatMap/SingleHeatRow.tsx
+++ b/frontend/src/Components/Charts/HeatMap/SingleHeatRow.tsx
@@ -55,6 +55,7 @@ function SingleHeatRow({
                   transform={howToTransform}
                   width={valueScale().bandwidth()}
                   height={bandwidth}
+                  opacity={colorFill === 'white' ? 0 : 1}
                   key={`${dataPoint.aggregateAttribute}-${point}`}
                 />
               </Tooltip>

--- a/frontend/src/HelperFunctions/Scales.ts
+++ b/frontend/src/HelperFunctions/Scales.ts
@@ -2,7 +2,7 @@ import { scaleBand, scaleLinear } from 'd3';
 import { Offset } from '../Interfaces/Types/OffsetType';
 import { greyScaleRange } from '../Presets/Constants';
 
-export const HeatmapColorScale = scaleLinear().domain([0, 1]).range([0.1, 1]);
+export const HeatmapColorScale = scaleLinear().domain([0, 1]).range([0, 1]);
 export const HeatmapGreyScale = scaleLinear().domain([0, 1]).range(greyScaleRange);
 
 export const AggregationScaleGenerator = (

--- a/frontend/src/Presets/StyledSVGComponents.ts
+++ b/frontend/src/Presets/StyledSVGComponents.ts
@@ -34,7 +34,6 @@ export const ChartG = styled('g') <ChartGProps>`
 
 export const HeatMapRect = styled('rect')`
   y:0;
-  opacity:0.6;
   stroke-width:2;
 `;
 interface HeatMapDivideProp {


### PR DESCRIPTION
### Does this PR close any open issues?

### Give a longer description of what this PR addresses and why it's needed

- The heatmap is no longer slightly transparent. 
- Hovered rows no longer affect the color of the heatmap. 
- Hovered rows no longer have spacing in between, they fill gaps.

### Provide pictures/videos of the behavior before and after these changes (optional)

Because no transparency, the heatmap colors are stronger (perhaps needs a new color scale, or is this even better?)
![Screenshot 2025-04-09 at 5 23 08 PM](https://github.com/user-attachments/assets/f2fb9a37-c7b9-4b0c-b50d-8db2b56b7d3c)


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

n/a
