### PR TITLE
Fix: Missing Vent Data

### DIFF
--- a/backend/api/views/sql_queries/mariadb.py
+++ b/backend/api/views/sql_queries/mariadb.py
@@ -248,7 +248,7 @@ surgery_case_query = rf"""
         QUARTER(SURG.CASE_DATE) AS QUARTER,
         MONTH(SURG.CASE_DATE) AS MONTH,
         SURG.CASE_DATE,
-        VST.TOTAL_VENT_MINS > 1440, 1, 0 AS VENT,
+        VST.total_vent_mins > 1440 AS VENT,
         VST.APR_DRG_WEIGHT AS DRG_WEIGHT,
         VST.PAT_EXPIRED AS DEATH,
         BLNG.ECMO,


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed

Raised by Jing Zhang - University of Washington

'VENT' was returning all one value. 
Switched the SQL for 
`VST.TOTAL_VENT_MINS > 1440, 1, 0 AS VENT,`  
into  
`VST.total_vent_mins > 1440 AS VENT,` to return the proper boolean.

### Provide pictures/videos of the behavior before and after these changes (optional)

Before & After
<img width="921" alt="Screenshot 2025-04-25 at 9 45 06 AM" src="https://github.com/user-attachments/assets/d15f35d3-c688-4619-aeaf-29c80f14fcce" />
<img width="922" alt="Screenshot 2025-04-25 at 9 45 30 AM" src="https://github.com/user-attachments/assets/d569c551-3f18-4ae2-b934-ca65f224fea6" />


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

None
