### PR TITLE
Fix: True False Counts (#364)

### DIFF
--- a/frontend/src/Components/Charts/HeatMap/WrapperHeatMap.tsx
+++ b/frontend/src/Components/Charts/HeatMap/WrapperHeatMap.tsx
@@ -85,15 +85,16 @@ function WrapperHeatMap({ layout }: { layout: HeatMapLayoutElement }) {
         temporaryDataHolder[singleCase[yAxisVar]].data.push(singleCase);
         temporaryDataHolder[singleCase[yAxisVar]].patientIDList.add(singleCase.MRN);
       }
-      // }
     });
     const [tempCaseCount, outputData] = generateRegularData(temporaryDataHolder, store.provenanceState.showZero, xAxisVar);
     const [secondCaseCount, secondOutputData] = generateRegularData(secondaryTemporaryDataHolder, store.provenanceState.showZero, xAxisVar);
     stateUpdateWrapperUseJSON(data, outputData, setData);
     stateUpdateWrapperUseJSON(secondaryData, secondOutputData, setSecondaryData);
     store.chartStore.totalAggregatedCaseCount = (tempCaseCount as number) + (secondCaseCount as number);
-    setCaseCount(tempCaseCount as number);
-    setSecondaryCaseCount(secondCaseCount as number);
+
+    // Marks the 'true' and 'false' if attribute === 0.
+    setCaseCount(secondCaseCount as number);
+    setSecondaryCaseCount(tempCaseCount as number);
   }, [proceduresSelection, surgeryUrgencySelection, store.provenanceState.outcomeFilter,
     rawDateRange,
     store.provenanceState.showZero,


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #364 

### Give a longer description of what this PR addresses and why it's needed
The 'Outcome Comparison' true / false count totals were flipped.

Before: If an attribute (ECMO, TXA etc) had an SQL-returned value of 0, it was marked as true, all else false.
After: If an attribute (ECMO, TXA etc) had an SQL-returned value of 0, it is marked as false, all else true.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?
