### PR TITLE
Fix: Provider Names Now Appear (#371)

### DIFF
--- a/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
@@ -35,7 +35,7 @@ function CustomizedAxisOrdinal({
   }, [scaleDomain, scaleRange]);
 
   const axisTextOutput = useCallback((input: number) => {
-    if (store.configStore.privateMode && xAxisVar.includes('PROV_ID')) {
+    if (!store.configStore.privateMode && xAxisVar.includes('PROV_ID')) {
       const name = store.providerMappping[input] as string;
       return name ? `${name.slice(0, 1)}${name.slice(1).toLowerCase()}` : input;
     }

--- a/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
@@ -36,7 +36,7 @@ function CustomizedAxisOrdinal({
   }, [scaleDomain, scaleRange]);
 
   // Gets the provider name depending on the private mode setting
-  const getProviderName = usePrivateProvName;
+  const getProviderName = usePrivateProvName();
   // If the xAxisVar is a provider ID, we need to get the provider name for display.
   const getLabel = (label: number) => (xAxisVar.includes('PROV_ID') ? getProviderName(label) : label);
 

--- a/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../../Presets/StyledSVGComponents';
 import Store from '../../../Interfaces/Store';
 import { DumbbellDataPoint } from '../../../Interfaces/Types/DataTypes';
-import { usePrivateProvName } from '../../Hooks/PrivateModeLabeling';
+import { usePrivateProvLabel } from '../../Hooks/PrivateModeLabeling';
 
 function CustomizedAxisOrdinal({
   numberList, scaleDomain, scaleRange, xAxisVar, chartHeight, data,
@@ -36,9 +36,7 @@ function CustomizedAxisOrdinal({
   }, [scaleDomain, scaleRange]);
 
   // Gets the provider name depending on the private mode setting
-  const getProviderName = usePrivateProvName();
-  // If the xAxisVar is a provider ID, we need to get the provider name for display.
-  const getLabel = (label: number) => (xAxisVar.includes('PROV_ID') ? getProviderName(label) : label);
+  const getLabel = usePrivateProvLabel();
 
   // Add a new handler that updates both the local hoveredColumn state and the store.
   const handleColumnHover = (columnIndex: number | null) => {
@@ -87,8 +85,8 @@ function CustomizedAxisOrdinal({
                 fill={hoveredColumn === idx ? hoverStore.backgroundHoverColor : (idx % 2 === 1 ? 'white' : 'black')}
                 opacity={hoveredColumn === idx ? 0.5 : 0.05}
               />
-              <Tooltip title={getLabel(numberOb.bin)} arrow>
-                <AxisText biggerFont={store.configStore.largeFont} x={x1} width={x2 - x1}>{getLabel(numberOb.bin)}</AxisText>
+              <Tooltip title={getLabel(numberOb.bin, xAxisVar)} arrow>
+                <AxisText biggerFont={store.configStore.largeFont} x={x1} width={x2 - x1}>{getLabel(numberOb.bin, xAxisVar)}</AxisText>
               </Tooltip>
 
             </g>

--- a/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/CustomizedAxisOrdinal.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../../Presets/StyledSVGComponents';
 import Store from '../../../Interfaces/Store';
 import { DumbbellDataPoint } from '../../../Interfaces/Types/DataTypes';
+import { usePrivateProvName } from '../../Hooks/PrivateModeLabeling';
 
 function CustomizedAxisOrdinal({
   numberList, scaleDomain, scaleRange, xAxisVar, chartHeight, data,
@@ -34,13 +35,10 @@ function CustomizedAxisOrdinal({
     return sc;
   }, [scaleDomain, scaleRange]);
 
-  const axisTextOutput = useCallback((input: number) => {
-    if (!store.configStore.privateMode && xAxisVar.includes('PROV_ID')) {
-      const name = store.providerMappping[input] as string;
-      return name ? `${name.slice(0, 1)}${name.slice(1).toLowerCase()}` : input;
-    }
-    return input;
-  }, [store.configStore.privateMode, store.providerMappping, xAxisVar]);
+  // Gets the provider name depending on the private mode setting
+  const getProviderName = usePrivateProvName;
+  // If the xAxisVar is a provider ID, we need to get the provider name for display.
+  const getLabel = (label: number) => (xAxisVar.includes('PROV_ID') ? getProviderName(label) : label);
 
   // Add a new handler that updates both the local hoveredColumn state and the store.
   const handleColumnHover = (columnIndex: number | null) => {
@@ -89,8 +87,8 @@ function CustomizedAxisOrdinal({
                 fill={hoveredColumn === idx ? hoverStore.backgroundHoverColor : (idx % 2 === 1 ? 'white' : 'black')}
                 opacity={hoveredColumn === idx ? 0.5 : 0.05}
               />
-              <Tooltip title={axisTextOutput(numberOb.bin)}>
-                <AxisText biggerFont={store.configStore.largeFont} x={x1} width={x2 - x1}>{axisTextOutput(numberOb.bin)}</AxisText>
+              <Tooltip title={getLabel(numberOb.bin)} arrow>
+                <AxisText biggerFont={store.configStore.largeFont} x={x1} width={x2 - x1}>{getLabel(numberOb.bin)}</AxisText>
               </Tooltip>
 
             </g>

--- a/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.tsx
@@ -8,7 +8,7 @@ import { AggregationScaleGenerator } from '../../../HelperFunctions/Scales';
 import { Offset } from '../../../Interfaces/Types/OffsetType';
 import Store from '../../../Interfaces/Store';
 import { Aggregation } from '../../../Presets/DataDict';
-import { usePrivateProvName } from '../../Hooks/PrivateModeLabeling';
+import { usePrivateProvLabel } from '../../Hooks/PrivateModeLabeling';
 
 type Props = {
     svg: RefObject<SVGSVGElement>;
@@ -28,7 +28,7 @@ function HeatMapAxis({
   const aggregationLabel = axisLeft(aggregationScale());
 
   // Gets the provider name depending on the private mode setting
-  const getProviderName = usePrivateProvName();
+  const getLabel = usePrivateProvLabel();
 
   svgSelection
     .select('.axes-y')
@@ -43,7 +43,7 @@ function HeatMapAxis({
     .attr('font-size', store.configStore.largeFont ? largeFontSize : regularFontSize)
     .attr('transform', `translate(-${CaseRectWidth + 2},0)`)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .text((d: any) => (yAxisVar.includes('PROV_ID') ? getProviderName(d) : d))
+    .text((d: any) => getLabel(d, yAxisVar))
     .attr('cursor', 'pointer')
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .on('click', (e, d: any) => {

--- a/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.tsx
@@ -28,7 +28,7 @@ function HeatMapAxis({
   const aggregationLabel = axisLeft(aggregationScale());
 
   // Gets the provider name depending on the private mode setting
-  const getProviderName = usePrivateProvName;
+  const getProviderName = usePrivateProvName();
 
   svgSelection
     .select('.axes-y')

--- a/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.tsx
@@ -26,6 +26,15 @@ function HeatMapAxis({
   const svgSelection = select(svg.current);
   const aggregationLabel = axisLeft(aggregationScale());
 
+  const privateModeNaming = useCallback((input: string) => {
+    // Use provider name if private mode is OFF and xAxisVar includes 'PROV_ID'
+    if (!store.configStore.privateMode && yAxisVar.includes('PROV_ID')) {
+      const name = store.providerMappping[Number(input)] as string;
+      return name ? `${name.slice(0, 1)}${name.slice(1).toLowerCase()}` : input;
+    }
+    return input;
+  }, [store.configStore.privateMode, store.providerMappping, yAxisVar]);
+
   svgSelection
     .select('.axes-y')
     .select('.y-axis')
@@ -39,7 +48,7 @@ function HeatMapAxis({
     .attr('font-size', store.configStore.largeFont ? largeFontSize : regularFontSize)
     .attr('transform', `translate(-${CaseRectWidth + 2},0)`)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .text((d: any) => d)
+    .text((d: any) => privateModeNaming(d))
     .attr('cursor', 'pointer')
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .on('click', (e, d: any) => {

--- a/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.tsx
@@ -8,6 +8,7 @@ import { AggregationScaleGenerator } from '../../../HelperFunctions/Scales';
 import { Offset } from '../../../Interfaces/Types/OffsetType';
 import Store from '../../../Interfaces/Store';
 import { Aggregation } from '../../../Presets/DataDict';
+import { usePrivateProvName } from '../../Hooks/PrivateModeLabeling';
 
 type Props = {
     svg: RefObject<SVGSVGElement>;
@@ -26,14 +27,8 @@ function HeatMapAxis({
   const svgSelection = select(svg.current);
   const aggregationLabel = axisLeft(aggregationScale());
 
-  const privateModeNaming = useCallback((input: string) => {
-    // Use provider name if private mode is OFF and xAxisVar includes 'PROV_ID'
-    if (!store.configStore.privateMode && yAxisVar.includes('PROV_ID')) {
-      const name = store.providerMappping[Number(input)] as string;
-      return name ? `${name.slice(0, 1)}${name.slice(1).toLowerCase()}` : input;
-    }
-    return input;
-  }, [store.configStore.privateMode, store.providerMappping, yAxisVar]);
+  // Gets the provider name depending on the private mode setting
+  const getProviderName = usePrivateProvName;
 
   svgSelection
     .select('.axes-y')
@@ -48,7 +43,7 @@ function HeatMapAxis({
     .attr('font-size', store.configStore.largeFont ? largeFontSize : regularFontSize)
     .attr('transform', `translate(-${CaseRectWidth + 2},0)`)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .text((d: any) => privateModeNaming(d))
+    .text((d: any) => (yAxisVar.includes('PROV_ID') ? getProviderName(d) : d))
     .attr('cursor', 'pointer')
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .on('click', (e, d: any) => {

--- a/frontend/src/Components/Charts/CostBarChart.tsx
+++ b/frontend/src/Components/Charts/CostBarChart.tsx
@@ -28,7 +28,7 @@ import { CostBarChartDataPoint, SingleCasePoint } from '../../Interfaces/Types/D
 import { sortHelper } from '../../HelperFunctions/ChartSorting';
 import ComparisonLegend from './ChartAccessories/ComparisonLegend';
 import { CostLayoutElement } from '../../Interfaces/Types/LayoutTypes';
-import { usePrivateProvName } from '../Hooks/PrivateModeLabeling';
+import { usePrivateProvLabel } from '../Hooks/PrivateModeLabeling';
 
 type TempDataItem = {
   aggregateAttribute: string | number;
@@ -197,9 +197,7 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
   const [xVals, setXVals] = useState<string[]>([]);
 
   // Gets the provider name depending on the private mode setting
-  const getProviderName = usePrivateProvName();
-  // If the xAxisVar is a provider ID, we need to get the provider name for display.
-  const getLabel = (label: string | number) => (yAxisVar.includes('PROV_ID') ? getProviderName(label) : label);
+  const getLabel = usePrivateProvLabel();
 
   useDeepCompareEffect(() => {
     const [tempxVals, _] = sortHelper(data, yAxisVar, store.provenanceState.showZero, secondaryData);
@@ -225,7 +223,7 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
     filteredCases.forEach((singleCase: SingleCasePoint) => {
       if (!temporaryDataHolder[singleCase[yAxisVar]]) {
         temporaryDataHolder[singleCase[yAxisVar]] = {
-          aggregateAttribute: getLabel(singleCase[yAxisVar]),
+          aggregateAttribute: getLabel(singleCase[yAxisVar], yAxisVar),
           PRBC_UNITS: 0,
           FFP_UNITS: 0,
           CRYO_UNITS: 0,
@@ -236,7 +234,7 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
           caseIDList: new Set(),
         };
         secondaryTemporaryDataHolder[singleCase[yAxisVar]] = {
-          aggregateAttribute: getLabel(singleCase[yAxisVar]),
+          aggregateAttribute: getLabel(singleCase[yAxisVar], yAxisVar),
           PRBC_UNITS: 0,
           FFP_UNITS: 0,
           CRYO_UNITS: 0,

--- a/frontend/src/Components/Charts/CostBarChart.tsx
+++ b/frontend/src/Components/Charts/CostBarChart.tsx
@@ -207,6 +207,15 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
     return aggScale;
   }, [dimensionHeight, xVals, currentOffset]);
 
+  const privateModeNaming = useCallback((input: string | number) => {
+    // Use provider name if private mode is OFF and xAxisVar includes 'PROV_ID'
+    if (!store.configStore.privateMode && yAxisVar.includes('PROV_ID')) {
+      const name = store.providerMappping[Number(input)] as string;
+      return name ? `${name.slice(0, 1)}${name.slice(1).toLowerCase()}` : input;
+    }
+    return input;
+  }, [store.configStore.privateMode, store.providerMappping, yAxisVar]);
+
   useDeepCompareEffect(() => {
     let tempmaxCost = 0;
     let tempMinCost = 0;
@@ -218,7 +227,7 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
     filteredCases.forEach((singleCase: SingleCasePoint) => {
       if (!temporaryDataHolder[singleCase[yAxisVar]]) {
         temporaryDataHolder[singleCase[yAxisVar]] = {
-          aggregateAttribute: singleCase[yAxisVar],
+          aggregateAttribute: privateModeNaming(singleCase[yAxisVar]),
           PRBC_UNITS: 0,
           FFP_UNITS: 0,
           CRYO_UNITS: 0,
@@ -229,7 +238,7 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
           caseIDList: new Set(),
         };
         secondaryTemporaryDataHolder[singleCase[yAxisVar]] = {
-          aggregateAttribute: singleCase[yAxisVar],
+          aggregateAttribute: privateModeNaming(singleCase[yAxisVar]),
           PRBC_UNITS: 0,
           FFP_UNITS: 0,
           CRYO_UNITS: 0,
@@ -292,7 +301,7 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
     }
     store.chartStore.totalAggregatedCaseCount = totalCaseCountTemp + secondaryCaseCountTemp;
     stateUpdateWrapperUseJSON(data, outputData, setData);
-  }, [proceduresSelection, rawDateRange, yAxisVar, currentOutputFilterSet, BloodProductCost, filteredCases, outcomeComparison, interventionDate]);
+  }, [proceduresSelection, rawDateRange, yAxisVar, currentOutputFilterSet, BloodProductCost, filteredCases, outcomeComparison, interventionDate, store.configStore.privateMode]);
 
   const spec = useMemo(() => ({
     $schema: 'https://vega.github.io/schema/vega-lite/v5.json',

--- a/frontend/src/Components/Charts/CostBarChart.tsx
+++ b/frontend/src/Components/Charts/CostBarChart.tsx
@@ -28,6 +28,7 @@ import { CostBarChartDataPoint, SingleCasePoint } from '../../Interfaces/Types/D
 import { sortHelper } from '../../HelperFunctions/ChartSorting';
 import ComparisonLegend from './ChartAccessories/ComparisonLegend';
 import { CostLayoutElement } from '../../Interfaces/Types/LayoutTypes';
+import { usePrivateProvName } from '../Hooks/PrivateModeLabeling';
 
 type TempDataItem = {
   aggregateAttribute: string | number;
@@ -207,14 +208,10 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
     return aggScale;
   }, [dimensionHeight, xVals, currentOffset]);
 
-  const privateModeNaming = useCallback((input: string | number) => {
-    // Use provider name if private mode is OFF and xAxisVar includes 'PROV_ID'
-    if (!store.configStore.privateMode && yAxisVar.includes('PROV_ID')) {
-      const name = store.providerMappping[Number(input)] as string;
-      return name ? `${name.slice(0, 1)}${name.slice(1).toLowerCase()}` : input;
-    }
-    return input;
-  }, [store.configStore.privateMode, store.providerMappping, yAxisVar]);
+  // Gets the provider name depending on the private mode setting
+  const getProviderName = usePrivateProvName;
+  // If the xAxisVar is a provider ID, we need to get the provider name for display.
+  const getLabel = (label: string | number) => (yAxisVar.includes('PROV_ID') ? getProviderName(label) : label);
 
   useDeepCompareEffect(() => {
     let tempmaxCost = 0;
@@ -227,7 +224,7 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
     filteredCases.forEach((singleCase: SingleCasePoint) => {
       if (!temporaryDataHolder[singleCase[yAxisVar]]) {
         temporaryDataHolder[singleCase[yAxisVar]] = {
-          aggregateAttribute: privateModeNaming(singleCase[yAxisVar]),
+          aggregateAttribute: getLabel(singleCase[yAxisVar]),
           PRBC_UNITS: 0,
           FFP_UNITS: 0,
           CRYO_UNITS: 0,
@@ -238,7 +235,7 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
           caseIDList: new Set(),
         };
         secondaryTemporaryDataHolder[singleCase[yAxisVar]] = {
-          aggregateAttribute: privateModeNaming(singleCase[yAxisVar]),
+          aggregateAttribute: getLabel(singleCase[yAxisVar]),
           PRBC_UNITS: 0,
           FFP_UNITS: 0,
           CRYO_UNITS: 0,

--- a/frontend/src/Components/Charts/CostBarChart.tsx
+++ b/frontend/src/Components/Charts/CostBarChart.tsx
@@ -195,6 +195,12 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
 
   const currentOffset = OffsetDict.regular;
   const [xVals, setXVals] = useState<string[]>([]);
+
+  // Gets the provider name depending on the private mode setting
+  const getProviderName = usePrivateProvName();
+  // If the xAxisVar is a provider ID, we need to get the provider name for display.
+  const getLabel = (label: string | number) => (yAxisVar.includes('PROV_ID') ? getProviderName(label) : label);
+
   useDeepCompareEffect(() => {
     const [tempxVals, _] = sortHelper(data, yAxisVar, store.provenanceState.showZero, secondaryData);
     setXVals(tempxVals);
@@ -207,11 +213,6 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
       .paddingInner(0.1);
     return aggScale;
   }, [dimensionHeight, xVals, currentOffset]);
-
-  // Gets the provider name depending on the private mode setting
-  const getProviderName = usePrivateProvName;
-  // If the xAxisVar is a provider ID, we need to get the provider name for display.
-  const getLabel = (label: string | number) => (yAxisVar.includes('PROV_ID') ? getProviderName(label) : label);
 
   useDeepCompareEffect(() => {
     let tempmaxCost = 0;

--- a/frontend/src/Components/Charts/HeatMap/WrapperHeatMap.tsx
+++ b/frontend/src/Components/Charts/HeatMap/WrapperHeatMap.tsx
@@ -60,7 +60,6 @@ function WrapperHeatMap({ layout }: { layout: HeatMapLayoutElement }) {
   }, [extraPairArray, data, filteredCases, secondaryData, outcomeComparison, interventionDate]);
 
   const size = useComponentSize(svgRef);
-  const yAxisMargin = 40;
 
   useDeepCompareEffect(() => {
     const temporaryDataHolder: Record<string | number, { data: SingleCasePoint[], aggregateAttribute: string | number, patientIDList: Set<number> }> = {};
@@ -120,7 +119,7 @@ function WrapperHeatMap({ layout }: { layout: HeatMapLayoutElement }) {
             dimensionWidth={size.width}
             data={data}
             svg={svgRef}
-            extraPairTotalWidth={extraPairTotalWidth + yAxisMargin}
+            extraPairTotalWidth={extraPairTotalWidth}
             yAxisVar={yAxisVar}
             xAxisVar={xAxisVar}
             chartId={chartId}

--- a/frontend/src/Components/Charts/HeatMap/WrapperHeatMap.tsx
+++ b/frontend/src/Components/Charts/HeatMap/WrapperHeatMap.tsx
@@ -60,6 +60,7 @@ function WrapperHeatMap({ layout }: { layout: HeatMapLayoutElement }) {
   }, [extraPairArray, data, filteredCases, secondaryData, outcomeComparison, interventionDate]);
 
   const size = useComponentSize(svgRef);
+  const yAxisMargin = 40;
 
   useDeepCompareEffect(() => {
     const temporaryDataHolder: Record<string | number, { data: SingleCasePoint[], aggregateAttribute: string | number, patientIDList: Set<number> }> = {};
@@ -119,7 +120,7 @@ function WrapperHeatMap({ layout }: { layout: HeatMapLayoutElement }) {
             dimensionWidth={size.width}
             data={data}
             svg={svgRef}
-            extraPairTotalWidth={extraPairTotalWidth}
+            extraPairTotalWidth={extraPairTotalWidth + yAxisMargin}
             yAxisVar={yAxisVar}
             xAxisVar={xAxisVar}
             chartId={chartId}

--- a/frontend/src/Components/Hooks/PrivateModeLabeling.tsx
+++ b/frontend/src/Components/Hooks/PrivateModeLabeling.tsx
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import Store from '../../Interfaces/Store';
+
+// Finds the provider name based on the input and the private mode setting.
+export function usePrivateProvName(input: string | number): string {
+  const store = useContext(Store);
+  if (!store.configStore.privateMode) {
+    const name = store.providerMappping[Number(input)] as string;
+    return name ? `${name.slice(0, 1)}${name.slice(1).toLowerCase()}` : String(input);
+  }
+  return String(input);
+}

--- a/frontend/src/Components/Hooks/PrivateModeLabeling.tsx
+++ b/frontend/src/Components/Hooks/PrivateModeLabeling.tsx
@@ -1,12 +1,13 @@
-import { useContext } from 'react';
+import { useContext, useCallback } from 'react';
 import Store from '../../Interfaces/Store';
 
-// Finds the provider name based on the input and the private mode setting.
-export function usePrivateProvName(input: string | number): string {
+export function usePrivateProvName(): (input: string | number) => string {
   const store = useContext(Store);
-  if (!store.configStore.privateMode) {
-    const name = store.providerMappping[Number(input)] as string;
-    return name ? `${name.slice(0, 1)}${name.slice(1).toLowerCase()}` : String(input);
-  }
-  return String(input);
+  return useCallback((input: string | number): string => {
+    if (!store.configStore.privateMode) {
+      const name = store.providerMappping[Number(input)] as string;
+      return name ? `${name.charAt(0)}${name.slice(1).toLowerCase()}` : String(input);
+    }
+    return String(input);
+  }, [store.configStore.privateMode, store.providerMappping]);
 }

--- a/frontend/src/Components/Hooks/PrivateModeLabeling.tsx
+++ b/frontend/src/Components/Hooks/PrivateModeLabeling.tsx
@@ -1,13 +1,23 @@
 import { useContext, useCallback } from 'react';
 import Store from '../../Interfaces/Store';
 
-export function usePrivateProvName(): (input: string | number) => string {
+/**
+ * Transforms a label based on the given attribute and private mode settings.
+ *
+ * @param label - The label to be transformed (string or number).
+ * @param attribute - The attribute associated with the label.
+ * @returns The transformed label. If private mode is enabled, provider names are not revealed.
+ */
+export function usePrivateProvLabel(): (label: string | number, attribute: string) => string {
   const store = useContext(Store);
-  return useCallback((input: string | number): string => {
-    if (!store.configStore.privateMode) {
-      const name = store.providerMappping[Number(input)] as string;
-      return name ? `${name.charAt(0)}${name.slice(1).toLowerCase()}` : String(input);
+
+  // If private mode is enabled, return the label as a string.
+  return useCallback((label: string | number, attribute: string): string => {
+    // If getting provider label, get the provider name if private mode is disabled.
+    if (!store.configStore.privateMode && attribute.includes('PROV_ID')) {
+      const name = store.providerMappping[Number(label)] as string;
+      return name ? `${name.charAt(0)}${name.slice(1).toLowerCase()}` : String(label);
     }
-    return String(input);
+    return String(label);
   }, [store.configStore.privateMode, store.providerMappping]);
 }


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #371 

### Give a longer description of what this PR addresses and why it's needed

Some charts were not showing provider names instead of codes when private mode is off.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
![Screenshot 2025-04-25 at 9 58 15 PM](https://github.com/user-attachments/assets/c6257aba-cc83-44c5-94ce-8fba59f3cfb9)

After:
![Screenshot 2025-04-25 at 9 58 36 PM](https://github.com/user-attachments/assets/b2b5dfed-2f12-4205-bb4c-d7948913d321)


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

None
