### PR TITLE
 Fix: Procedure Button Errors & Styles (#311, #336)

### DIFF
--- a/frontend/src/Components/Utilities/LeftToolBox/SurgeryListViewer.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/SurgeryListViewer.tsx
@@ -95,10 +95,12 @@ function SurgeryListViewer({ surgeryList, maxCaseCount }: Props) {
             </tr>
           </thead>
           <tbody>
+            {/** Render Selected Procedures */}
             {itemSelected.flatMap((listItem: ProcedureEntry) => {
+              // If the procedure is expanded (inside expandedList), render the sub-procedures as well
               if (expandedList.includes(listItem.procedureName) && listItem.overlapList) {
                 return [<SurgeryRow
-                  key={listItem.procedureName}
+                  key={`main-${listItem.procedureName}`}
                   expandedList={expandedList}
                   setExpandedList={setExpandedList}
                   listItem={listItem}
@@ -109,10 +111,10 @@ function SurgeryListViewer({ surgeryList, maxCaseCount }: Props) {
                   width={width}
                   caseScaleRange={JSON.stringify(caseScale().range())}
                 />,
-
-                ].concat(listItem.overlapList.map((subItem: ProcedureEntry) => (
+                // Render sub-procedures contained in the 'overlapList'
+                ].concat(listItem.overlapList.map((subItem: ProcedureEntry, subIndex: number) => (
                   <SurgeryRow
-                    key={subItem.procedureName}
+                    key={`sub-${listItem.procedureName}-${subItem.procedureName}-${subIndex}`}
                     expandedList={expandedList}
                     setExpandedList={setExpandedList}
                     listItem={subItem}
@@ -126,9 +128,10 @@ function SurgeryListViewer({ surgeryList, maxCaseCount }: Props) {
                   />
                 )));
               }
+              // If the procedure is not expanded, render the procedure only
               return [
                 <SurgeryRow
-                  key={listItem.procedureName}
+                  key={`main-${listItem.procedureName}`}
                   expandedList={expandedList}
                   setExpandedList={setExpandedList}
                   listItem={listItem}
@@ -141,10 +144,12 @@ function SurgeryListViewer({ surgeryList, maxCaseCount }: Props) {
                 />,
               ];
             })}
+            {/** Render Unselected Procedures */}
             {itemUnselected.flatMap((listItem: ProcedureEntry) => {
+              // If the procedure is expanded, render the sub-procedures as well
               if (expandedList.includes(listItem.procedureName) && listItem.overlapList) {
                 return [<SurgeryRow
-                  key={listItem.procedureName}
+                  key={`main-${listItem.procedureName}`}
                   listItem={listItem}
                   expandedList={expandedList}
                   setExpandedList={setExpandedList}
@@ -155,9 +160,10 @@ function SurgeryListViewer({ surgeryList, maxCaseCount }: Props) {
                   width={width}
                   caseScaleRange={JSON.stringify(caseScale().range())}
                 />,
-                ].concat(listItem.overlapList.map((subItem: ProcedureEntry) => (
+                // Render sub-procedures contained in the 'overlapList'
+                ].concat(listItem.overlapList.map((subItem: ProcedureEntry, subIndex: number) => (
                   <SurgeryRow
-                    key={subItem.procedureName}
+                    key={`sub-${listItem.procedureName}-${subItem.procedureName}-${subIndex}`}
                     listItem={subItem}
                     selected={false}
                     expandedList={expandedList}
@@ -171,8 +177,9 @@ function SurgeryListViewer({ surgeryList, maxCaseCount }: Props) {
                   />
                 )));
               }
+              // If the procedure is not expanded, render the procedure only
               return [<SurgeryRow
-                key={listItem.procedureName}
+                key={`main-${listItem.procedureName}`}
                 listItem={listItem}
                 expandedList={expandedList}
                 setExpandedList={setExpandedList}

--- a/frontend/src/Components/Utilities/LeftToolBox/SurgeryRow.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/SurgeryRow.tsx
@@ -55,9 +55,10 @@ function SurgeryRow({
       <SurgeryDiv ref={spanRef} onClick={() => { store.selectionStore.updateProcedureSelection(listItem, selected, isSubSurgery ? parentSurgery : undefined); }}>
         {isSubSurgery
           ? (
+            // Sub-procedure row
             <>
               {' '}
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+              &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
               {listItem.procedureName.includes('Only') ? '' : '+'}
               <span
                 onMouseOver={mouseOverHandler}
@@ -68,7 +69,9 @@ function SurgeryRow({
             </>
           )
           : (
+            // Main-procedure row
             <>
+              {/** If the main procedure is expanded or collapsed */}
               <span onClick={(event) => {
                 if (expandedList.includes(listItem.procedureName)) {
                   setExpandedList(expandedList.filter((d) => d !== listItem.procedureName));
@@ -80,6 +83,7 @@ function SurgeryRow({
               >
                 {expandedList.includes(listItem.procedureName) ? '▼' : '►'}
               </span>
+              {/** Main Procedure name */}
               <span
                 onMouseOver={mouseOverHandler}
                 onMouseLeave={mouseLeaveHandler}

--- a/frontend/src/Components/Utilities/LeftToolBox/SurgeryRow.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/SurgeryRow.tsx
@@ -3,6 +3,8 @@ import { observer } from 'mobx-react-lite';
 import {
   Dispatch, SetStateAction, useCallback, useContext, useRef, useState,
 } from 'react';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import Store from '../../../Interfaces/Store';
 import { ProcedureEntry } from '../../../Interfaces/Types/DataTypes';
 import { SurgeryListComp, SurgeryDiv, SurgeryNumText } from '../../../Presets/StyledComponents';
@@ -72,24 +74,29 @@ function SurgeryRow({
             // Main-procedure row
             <>
               {/** If the main procedure is expanded or collapsed */}
-              <span onClick={(event) => {
-                if (expandedList.includes(listItem.procedureName)) {
-                  setExpandedList(expandedList.filter((d) => d !== listItem.procedureName));
-                } else {
-                  setExpandedList([...expandedList, listItem.procedureName]);
-                }
-                event.stopPropagation();
-              }}
-              >
-                {expandedList.includes(listItem.procedureName) ? '▼' : '►'}
-              </span>
-              {/** Main Procedure name */}
-              <span
-                onMouseOver={mouseOverHandler}
-                onMouseLeave={mouseLeaveHandler}
-              >
-                {listItem.procedureName}
-              </span>
+              <div style={{ display: 'inline-flex', alignItems: 'center' }}>
+                <span onClick={(event) => {
+                  if (expandedList.includes(listItem.procedureName)) {
+                    setExpandedList(expandedList.filter((d) => d !== listItem.procedureName));
+                  } else {
+                    setExpandedList([...expandedList, listItem.procedureName]);
+                  }
+                  event.stopPropagation();
+                }}
+                >
+                  {/** Expanded or collapsed icons */}
+                  {expandedList.includes(listItem.procedureName)
+                    ? <KeyboardArrowDownIcon fontSize="small" style={{ verticalAlign: 'middle' }} />
+                    : <ChevronRightIcon fontSize="small" style={{ verticalAlign: 'middle' }} />}
+                </span>
+                {/** Main Procedure name */}
+                <span
+                  onMouseOver={mouseOverHandler}
+                  onMouseLeave={mouseLeaveHandler}
+                >
+                  {listItem.procedureName}
+                </span>
+              </div>
             </>
           )}
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #311 #336 

### Give a longer description of what this PR addresses and why it's needed
The procedure selection previously was
- Duplicating Selections
- Duplicating expanded procedure lists
- Expanded lists would not collapse again on toggle
- Icons were triangles not arrows

This PR fixes those issues, and changes the styles of expand/collapse toggle icons. 

### Provide pictures/videos of the behavior before and after these changes (optional)
**Before** (For example: Clicking on procedures wasn't working, toggle collapse wasn't working)

https://github.com/user-attachments/assets/2890583d-bbf0-4ec1-9ca7-1a623056cc54

**After**

https://github.com/user-attachments/assets/1137e7b8-3218-44d9-bba2-784487e4dffa


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?
None
