### PR TITLE
Fix: Dumbbell Charts Clear If Without Data (#365)

### DIFF
--- a/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
+++ b/frontend/src/Components/Charts/DumbbellChart/DumbbellChart.tsx
@@ -138,7 +138,21 @@ function DumbbellChart({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortMode]);
 
+  function clearState() {
+    stateUpdateWrapperUseJSON(sortedData, [], setSortedData);
+    stateUpdateWrapperUseJSON(numberList, [], setNumberList);
+    stateUpdateWrapperUseJSON(dataPointDict, [], setDataPointDict);
+    stateUpdateWrapperUseJSON(resultRange, [], setResultRange);
+    stateUpdateWrapperUseJSON(averageForEachTransfused, {}, setAverage);
+  }
+
   useDeepCompareEffect(() => {
+    // Clear out states when there is no data
+    if (data.length === 0) {
+      clearState();
+      return;
+    }
+
     const spacing: Record<number, number> = {};
 
     let totalWidth = 0;
@@ -163,7 +177,7 @@ function DumbbellChart({
     });
     stateUpdateWrapperUseJSON(resultRange, newResultRange, setResultRange);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataPointDict, dimensionWidth, currentOffset, sortedData]);
+  }, [dataPointDict, dimensionWidth, currentOffset, sortedData, data]);
 
   const testValueScale = useCallback(() => scaleLinear()
     .domain([0.9 * xMin, 1.1 * xMax])


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #365 

### Give a longer description of what this PR addresses and why it's needed
As described in #365 , dumbbell charts were not fully clearing when multiple procedure selections resulted in no cases (no data).

### Provide pictures/videos of the behavior before and after these changes (optional)
**Before** (Multiple selections which result in zero cases, crashes the chart):

![Screenshot 2025-04-28 at 12 04 07 PM](https://github.com/user-attachments/assets/f79c010c-abe7-4c1e-ad61-77a5f32ac6e2)

**After:** (Multiple selections which result in zero cases, results in a clear chart like it should):

![Screenshot 2025-04-28 at 12 05 08 PM](https://github.com/user-attachments/assets/586a3cde-c454-4c1a-a8fc-40c00f75c6d8)

### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

None
