### PR TITLE
Labels Have More Room

### DIFF
--- a/frontend/src/Presets/Constants.ts
+++ b/frontend/src/Presets/Constants.ts
@@ -12,7 +12,7 @@ export const SnackBarCloseTime = 5000;
 export const HGB_HIGH_STANDARD = 13;
 export const OffsetDict = {
   regular: {
-    left: 110, bottom: 40, right: 10, top: 40, margin: 10,
+    left: 140, bottom: 40, right: 10, top: 40, margin: 10,
   } as Offset,
   minimum: {
     left: 35, bottom: 40, right: 10, top: 40, margin: 10,


### PR DESCRIPTION
### Does this PR close any open issues?

### Give a longer description of what this PR addresses and why it's needed
More default room for y-axis labels to avoid truncation

### Provide pictures/videos of the behavior before and after these changes (optional)
![labelroom](https://github.com/user-attachments/assets/097752f4-f024-4e1a-9d5a-969dd845356b)


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?
None
