### PR TITLE
Fix: Cost/Savings Extra Plot Data Missing

### DIFF
--- a/frontend/src/Components/Charts/ChartAccessories/ExtraPairButtons.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/ExtraPairButtons.tsx
@@ -4,15 +4,15 @@ import {
 import { useContext, useState, MouseEvent } from 'react';
 import InsertChartIcon from '@mui/icons-material/InsertChart';
 import Store from '../../../Interfaces/Store';
-import { ExtraPairOptions } from '../../../Presets/DataDict';
 import { ExtraPairLimit } from '../../../Presets/Constants';
 
 type Props = {
     extraPairLength: number;
     chartId: string;
     disbleButton: boolean;
+    buttonOptions: { key: string; value: string }[];
 };
-function ExtraPairButtons({ extraPairLength, chartId, disbleButton }: Props) {
+function ExtraPairButtons({ extraPairLength, chartId, disbleButton, buttonOptions}: Props) {
   const store = useContext(Store);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
@@ -42,7 +42,7 @@ function ExtraPairButtons({ extraPairLength, chartId, disbleButton }: Props) {
         open={open}
         onClose={handleClose}
       >
-        {ExtraPairOptions.map((option) => (
+        {buttonOptions.map((option) => (
           <MenuItem key={option.key} onClick={() => { extraPairHandling(option.key); }}>{option.value}</MenuItem>
         ))}
       </Menu>

--- a/frontend/src/Components/Charts/CostBarChart.tsx
+++ b/frontend/src/Components/Charts/CostBarChart.tsx
@@ -13,7 +13,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import {
   ExtraPairPadding, ExtraPairWidth, MIN_HEATMAP_BANDWIDTH, OffsetDict, postopColor, preopColor,
 } from '../../Presets/Constants';
-import { BloodComponentOptions, ExtraPairOptions } from '../../Presets/DataDict';
+import { BloodComponentOptions, CostSavingsExtraPairOptions } from '../../Presets/DataDict';
 import { ChartWrapperContainer, ChartAccessoryDiv } from '../../Presets/StyledComponents';
 import AnnotationForm from './ChartAccessories/AnnotationForm';
 import CostInputDialog from '../Modals/CostInputDialog';
@@ -429,7 +429,7 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
             <Switch checked={showPotential} onChange={(e) => { setShowPotential(e.target.checked); }} />
           </Tooltip>
         </FormControl>
-        <ExtraPairButtons disbleButton={dimensionWidth * 0.6 < extraPairTotalWidth} extraPairLength={extraPairArray.length} chartId={chartId} buttonOptions={ExtraPairOptions} />
+        <ExtraPairButtons disbleButton={dimensionWidth * 0.6 < extraPairTotalWidth} extraPairLength={extraPairArray.length} chartId={chartId} buttonOptions={CostSavingsExtraPairOptions} />
         <ChartConfigMenu layout={layout} />
         <Tooltip title="Change blood component cost">
           <IconButton size="small" onClick={handleClick}>

--- a/frontend/src/Components/Charts/CostBarChart.tsx
+++ b/frontend/src/Components/Charts/CostBarChart.tsx
@@ -108,61 +108,69 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
     setAnchorEl(null);
   };
 
+  // Gets the provider name depending on the private mode setting
+  const getLabel = usePrivateProvLabel();
+
   const [data, setData] = useState<CostBarChartDataPoint[]>([]);
   const [secondaryData, setSecondaryData] = useState<CostBarChartDataPoint[]>([]);
   const plotData = useMemo(() => {
     const plotDataTemp = {
       values: data
-        .flatMap((d) => ([
-          showPotential ? {
-            rowLabel: d.aggregateAttribute, value: d.cellSalvageVolume * -0.004 * BloodProductCost.PRBC_UNITS, bloodProduct: 'savings', type: 'false',
-          } : null,
-          {
-            rowLabel: d.aggregateAttribute, value: d.PRBC_UNITS, bloodProduct: 'PRBC', type: 'false',
-          },
-          {
-            rowLabel: d.aggregateAttribute, value: d.FFP_UNITS, bloodProduct: 'FFP', type: 'false',
-          },
-          {
-            rowLabel: d.aggregateAttribute, value: d.CRYO_UNITS, bloodProduct: 'CRYO', type: 'false',
-          },
-          {
-            rowLabel: d.aggregateAttribute, value: d.PLT_UNITS, bloodProduct: 'PLT', type: 'false',
-          },
-          {
-            rowLabel: d.aggregateAttribute, value: d.CELL_SAVER_ML, bloodProduct: 'CELL_SAVER', type: 'false',
-          },
-        ]))
-        .filter((d) => d !== null),
+        .flatMap((d) => {
+          const label = getLabel(d.aggregateAttribute, yAxisVar);
+          return [
+            showPotential ? {
+              rowLabel: label, value: d.cellSalvageVolume * -0.004 * BloodProductCost.PRBC_UNITS, bloodProduct: 'savings', type: 'false',
+            } : null,
+            {
+              rowLabel: label, value: d.PRBC_UNITS, bloodProduct: 'PRBC', type: 'false',
+            },
+            {
+              rowLabel: label, value: d.FFP_UNITS, bloodProduct: 'FFP', type: 'false',
+            },
+            {
+              rowLabel: label, value: d.CRYO_UNITS, bloodProduct: 'CRYO', type: 'false',
+            },
+            {
+              rowLabel: label, value: d.PLT_UNITS, bloodProduct: 'PLT', type: 'false',
+            },
+            {
+              rowLabel: label, value: d.CELL_SAVER_ML, bloodProduct: 'CELL_SAVER', type: 'false',
+            },
+          ];
+        }).filter((d) => d !== null),
     };
     if (secondaryData.length > 0) {
       plotDataTemp.values = plotDataTemp.values.concat(
         secondaryData
-          .flatMap((d) => ([
-            showPotential ? {
-              rowLabel: d.aggregateAttribute, value: d.cellSalvageVolume * -0.004 * BloodProductCost.PRBC_UNITS, bloodProduct: 'savings', type: 'true',
-            } : null,
-            {
-              rowLabel: d.aggregateAttribute, value: d.PRBC_UNITS, bloodProduct: 'PRBC', type: 'true',
-            },
-            {
-              rowLabel: d.aggregateAttribute, value: d.FFP_UNITS, bloodProduct: 'FFP', type: 'true',
-            },
-            {
-              rowLabel: d.aggregateAttribute, value: d.CRYO_UNITS, bloodProduct: 'CRYO', type: 'true',
-            },
-            {
-              rowLabel: d.aggregateAttribute, value: d.PLT_UNITS, bloodProduct: 'PLT', type: 'true',
-            },
-            {
-              rowLabel: d.aggregateAttribute, value: d.CELL_SAVER_ML, bloodProduct: 'CELL_SAVER', type: 'true',
-            },
-          ]))
+          .flatMap((d) => {
+            const label = getLabel(d.aggregateAttribute, yAxisVar);
+            return [
+              showPotential ? {
+                rowLabel: label, value: d.cellSalvageVolume * -0.004 * BloodProductCost.PRBC_UNITS, bloodProduct: 'savings', type: 'true',
+              } : null,
+              {
+                rowLabel: label, value: d.PRBC_UNITS, bloodProduct: 'PRBC', type: 'true',
+              },
+              {
+                rowLabel: label, value: d.FFP_UNITS, bloodProduct: 'FFP', type: 'true',
+              },
+              {
+                rowLabel: label, value: d.CRYO_UNITS, bloodProduct: 'CRYO', type: 'true',
+              },
+              {
+                rowLabel: label, value: d.PLT_UNITS, bloodProduct: 'PLT', type: 'true',
+              },
+              {
+                rowLabel: label, value: d.CELL_SAVER_ML, bloodProduct: 'CELL_SAVER', type: 'true',
+              },
+            ];
+          })
           .filter((d) => d !== null),
       );
     }
     return plotDataTemp;
-  }, [BloodProductCost.PRBC_UNITS, data, secondaryData, showPotential]);
+  }, [BloodProductCost.PRBC_UNITS, data, secondaryData, showPotential, store.configStore.privateMode, yAxisVar]);
 
   const [extraPairArray, setExtraPairArray] = useState<string[]>([]);
   useEffect(() => {
@@ -196,9 +204,6 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
   const currentOffset = OffsetDict.regular;
   const [xVals, setXVals] = useState<string[]>([]);
 
-  // Gets the provider name depending on the private mode setting
-  const getLabel = usePrivateProvLabel();
-
   useDeepCompareEffect(() => {
     const [tempxVals, _] = sortHelper(data, yAxisVar, store.provenanceState.showZero, secondaryData);
     setXVals(tempxVals);
@@ -223,7 +228,7 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
     filteredCases.forEach((singleCase: SingleCasePoint) => {
       if (!temporaryDataHolder[singleCase[yAxisVar]]) {
         temporaryDataHolder[singleCase[yAxisVar]] = {
-          aggregateAttribute: getLabel(singleCase[yAxisVar], yAxisVar),
+          aggregateAttribute: singleCase[yAxisVar],
           PRBC_UNITS: 0,
           FFP_UNITS: 0,
           CRYO_UNITS: 0,
@@ -234,7 +239,7 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
           caseIDList: new Set(),
         };
         secondaryTemporaryDataHolder[singleCase[yAxisVar]] = {
-          aggregateAttribute: getLabel(singleCase[yAxisVar], yAxisVar),
+          aggregateAttribute: singleCase[yAxisVar],
           PRBC_UNITS: 0,
           FFP_UNITS: 0,
           CRYO_UNITS: 0,

--- a/frontend/src/Components/Charts/CostBarChart.tsx
+++ b/frontend/src/Components/Charts/CostBarChart.tsx
@@ -13,7 +13,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import {
   ExtraPairPadding, ExtraPairWidth, MIN_HEATMAP_BANDWIDTH, OffsetDict, postopColor, preopColor,
 } from '../../Presets/Constants';
-import { BloodComponentOptions } from '../../Presets/DataDict';
+import { BloodComponentOptions, ExtraPairOptions } from '../../Presets/DataDict';
 import { ChartWrapperContainer, ChartAccessoryDiv } from '../../Presets/StyledComponents';
 import AnnotationForm from './ChartAccessories/AnnotationForm';
 import CostInputDialog from '../Modals/CostInputDialog';
@@ -429,7 +429,7 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
             <Switch checked={showPotential} onChange={(e) => { setShowPotential(e.target.checked); }} />
           </Tooltip>
         </FormControl>
-        <ExtraPairButtons disbleButton={dimensionWidth * 0.6 < extraPairTotalWidth} extraPairLength={extraPairArray.length} chartId={chartId} />
+        <ExtraPairButtons disbleButton={dimensionWidth * 0.6 < extraPairTotalWidth} extraPairLength={extraPairArray.length} chartId={chartId} buttonOptions={ExtraPairOptions} />
         <ChartConfigMenu layout={layout} />
         <Tooltip title="Change blood component cost">
           <IconButton size="small" onClick={handleClick}>

--- a/frontend/src/Components/Charts/CostBarChart.tsx
+++ b/frontend/src/Components/Charts/CostBarChart.tsx
@@ -178,7 +178,7 @@ function WrapperCostBar({ layout }: { layout: CostLayoutElement }) {
       );
     }
     return plotDataTemp;
-  }, [BloodProductCost.PRBC_UNITS, costSavingsData, secondaryCostSavingsData, showPotential, store.configStore.privateMode, yAxisVar]);
+  }, [BloodProductCost.PRBC_UNITS, costSavingsData, secondaryCostSavingsData, showPotential, yAxisVar, getLabel]);
 
   const [extraPairArray, setExtraPairArray] = useState<string[]>([]);
   useEffect(() => {

--- a/frontend/src/Components/Charts/HeatMap/WrapperHeatMap.tsx
+++ b/frontend/src/Components/Charts/HeatMap/WrapperHeatMap.tsx
@@ -60,6 +60,7 @@ function WrapperHeatMap({ layout }: { layout: HeatMapLayoutElement }) {
 
   const size = useComponentSize(svgRef);
 
+  // Generating the extra attribute data for the extra pair plot ------------------------------------------------------------
   useDeepCompareEffect(() => {
     const [tempCaseCount, secondaryTempCaseCount, outputData, secondaryOutputData] = generateExtraAttributeData(filteredCases, yAxisVar, outcomeComparison, interventionDate, store.provenanceState.showZero, xAxisVar);
     stateUpdateWrapperUseJSON(data, outputData, setData);

--- a/frontend/src/Components/Charts/HeatMap/WrapperHeatMap.tsx
+++ b/frontend/src/Components/Charts/HeatMap/WrapperHeatMap.tsx
@@ -11,6 +11,7 @@ import Store from '../../../Interfaces/Store';
 import { ExtraPairPoint, HeatMapDataPoint } from '../../../Interfaces/Types/DataTypes';
 import HeatMap from './HeatMap';
 import ExtraPairButtons from '../ChartAccessories/ExtraPairButtons';
+import { ExtraPairOptions } from '../../../Presets/DataDict';
 import ChartConfigMenu from '../ChartAccessories/ChartConfigMenu';
 import AnnotationForm from '../ChartAccessories/AnnotationForm';
 import ChartStandardButtons from '../ChartStandardButtons';
@@ -82,7 +83,7 @@ function WrapperHeatMap({ layout }: { layout: HeatMapLayoutElement }) {
     <Container style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <ChartAccessoryDiv>
         {`Heatmap${(outcomeComparison || interventionDate) ? ' with Comparison' : ''}`}
-        <ExtraPairButtons disbleButton={size.width * 0.6 < extraPairTotalWidth} extraPairLength={extraPairArray.length} chartId={chartId} />
+        <ExtraPairButtons disbleButton={size.width * 0.6 < extraPairTotalWidth} extraPairLength={extraPairArray.length} chartId={chartId} buttonOptions={ExtraPairOptions} />
         <ChartConfigMenu layout={layout} />
         <ChartStandardButtons chartID={chartId} />
       </ChartAccessoryDiv>

--- a/frontend/src/Presets/DataDict.ts
+++ b/frontend/src/Presets/DataDict.ts
@@ -57,6 +57,16 @@ export const ExtraPairOptions: { key: typeof EXTRA_PAIR_OPTIONS[number]; value: 
   { key: 'DRG_WEIGHT', value: 'APR-DRG Weight' },
 ]);
 
+// Temporary options for cost/savings charts in terms of RBC only. (Because these charts dont have a variable x-axis)
+export const CostSavingsExtraPairOptions: { key: typeof EXTRA_PAIR_OPTIONS[number]; value: string }[] = (OutcomeOptions as any).concat([
+  { key: 'PREOP_HEMO', value: 'Preop HGB' },
+  { key: 'POSTOP_HEMO', value: 'Postop HGB' },
+  { key: 'TOTAL_TRANS', value: 'Total RBC Transfused' }, // Updated label
+  { key: 'PER_CASE', value: 'Per Case RBC' }, // Updated label
+  { key: 'ZERO_TRANS', value: 'Zero RBC Transfused' }, // Updated label
+  { key: 'DRG_WEIGHT', value: 'APR-DRG Weight' },
+]);
+
 const dumbbellValueOptions = [{ key: 'HGB_VALUE', value: 'Hemoglobin Value' }];
 
 const _CHART_TYPES = ['DUMBBELL', 'SCATTER', 'HEATMAP', 'COST'] as const;


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #325  

### Give a longer description of what this PR addresses and why it's needed
**Re-do of #331**



**_Before:_** #325 - Some 'additional attributes' data in the cost / savings chart were all the same value: `Total Transfused`, `Zero Transfused`, and `Per Case`.

**_Changes:_** 
- Re-used the (correct) additional-attribute data generation from `WrapperHeatMap.tsx`, into `CostBarChart.tsx`.
- `WrapperHeatMap.tsx` now generates and uses data _separately_ for the cost / savings chart vs. the additional attribute charts.

**_After:_**  The cost savings chart's 'additional attributes' have correct data (like the Heat Map does)

**_Caveats:_** 
- Cost / Savings chart's additional attributes are only in terms of `PRBC_UNITS` right now (because this chart has no x-axis options other than `Cost`). 
- `WrapperHeatMap` and `CostBarChart` should be refactored. For simplicity I will do this in another PR.

### Provide pictures/videos of the behavior before and after these changes (optional)

**_Before:_** The cost-savings chart had incorrect additional attribute data.
![Image](https://github.com/user-attachments/assets/0e598af5-2331-4c14-9906-e2ff9d55b99c)


**_After:_** Correct additional attributes data, with an x-axis of `PRBC_UNITS`
<img width="1062" alt="Screenshot 2025-03-12 at 12 37 47 PM" src="https://github.com/user-attachments/assets/4f838bc9-c3e0-407c-94f1-14526ad2ac7f" />


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Related future PRs:

- Different blood products can be displayed as extra plots (instead of just RBCs)  #381 
