### PR TITLE
'Currently Selected' Attribute Values Private Mode (#392)

### DIFF
--- a/frontend/src/Components/Utilities/LeftToolBox/CurrentSelected.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/CurrentSelected.tsx
@@ -11,6 +11,7 @@ import { AcronymDictionary } from '../../../Presets/DataDict';
 import {
   InheritWidthGrid, CenterAlignedDiv, Title,
 } from '../../../Presets/StyledComponents';
+import { usePrivateProvLabel } from '../../Hooks/PrivateModeLabeling';
 
 const TinyFontButton = styled(Button)({
   fontSize: 'xx-small!important',
@@ -19,6 +20,7 @@ const TinyFontButton = styled(Button)({
 function CurrentSelected() {
   const store = useContext(Store);
   const { currentSelectedPatientGroup, currentSelectSet } = store.provenanceState;
+  const getLabel = usePrivateProvLabel();
 
   return (
     <InheritWidthGrid item>
@@ -28,6 +30,7 @@ function CurrentSelected() {
             <Title>Currently Selected</Title>
           </ListItem>
 
+          {/** Currently Selected Cases */}
           {currentSelectedPatientGroup.length > 0
             ? (
               <ListItem alignItems="flex-start" style={{ width: '100%' }}>
@@ -43,12 +46,13 @@ function CurrentSelected() {
               </ListItem>
             )
             : null}
-
+          {/** Currently Selected Attributes */}
           {currentSelectSet.map((selectSet: SelectSet) => (
             <ListItem key={`${selectSet.setName}selected`}>
+              {/** primary = Attribute Name.  secondary = attribute values, different values for private mode. */}
               <ListItemText
                 primary={AcronymDictionary[selectSet.setName as keyof typeof AcronymDictionary] ? AcronymDictionary[selectSet.setName as keyof typeof AcronymDictionary] : selectSet.setName}
-                secondary={selectSet.setValues.sort().join(', ')}
+                secondary={store.configStore.privateMode ? selectSet.setValues.sort().join(', ') : selectSet.setValues.map((value) => getLabel(value, selectSet.setName)).sort().join(', ')}
               />
               <ListItemSecondaryAction>
                 <IconButton onClick={() => { store.interactionStore.clearSet(selectSet.setName); }}>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #392

### Give a longer description of what this PR addresses and why it's needed
'Currently Selected' provider name id's wouldn't switch to their names when private mode was turned off.

### Provide pictures/videos of the behavior before and after these changes (optional)

When private mode switches to off, name updates:
<img width="278" alt="Screenshot 2025-05-20 at 12 39 11 PM" src="https://github.com/user-attachments/assets/b890122f-7b52-43cd-8a56-be38241b0537" />

### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?
- [ ] Ensure this works for all updates