### PR TITLE
Selected Cases Private Mode

### DIFF
--- a/frontend/src/Components/Hooks/PrivateModeLabeling.tsx
+++ b/frontend/src/Components/Hooks/PrivateModeLabeling.tsx
@@ -13,11 +13,26 @@ export function usePrivateProvLabel(): (label: string | number, attribute: strin
 
   // Convert the label to a provider name or id depending on private mode setting.
   return useCallback((label: string | number, attribute: string): string => {
-    // If getting provider label, get the provider name if private mode is disabled.
-    if (!store.configStore.privateMode && attribute.includes('PROV_ID')) {
-      const name = store.providerMapping[label] as string;
-      return name ? `${name.charAt(0)}${name.slice(1).toLowerCase()}` : String(label);
+    // If the attribute is not a provider, return the label as is.
+    if (!attribute.includes('PROV_ID')) {
+      return String(label);
     }
-    return String(label);
+
+    // If private mode is enabled, return the provider id.
+    if (store.configStore.privateMode) {
+      const labelStr = String(label);
+
+      // If the label is an id, find the corresponding provider name.
+      const id = Object
+        .keys(store.providerMapping)
+        .find((key) => store.providerMapping[key] === labelStr);
+
+      // if we found one, return it, otherwise return the label itself
+      return id ?? labelStr;
+    }
+
+    // If private mode is disabled, return the provider name.
+    const name = store.providerMapping[label] as string;
+    return name ?? String(label);
   }, [store.configStore.privateMode, store.providerMapping]);
 }

--- a/frontend/src/Components/Utilities/DetailView/CaseList.tsx
+++ b/frontend/src/Components/Utilities/DetailView/CaseList.tsx
@@ -46,7 +46,7 @@ function CaseList() {
           >
             <ListItemButton onClick={() => store.interactionStore.setCurrentSelectPatient(d)}>
               <ListItemText primary={
-                                store.configStore.privateMode ? d.CASE_ID : '----------'
+                                store.configStore.privateMode ? '----------' : d.CASE_ID
                             }
               />
             </ListItemButton>

--- a/frontend/src/Components/Utilities/LeftToolBox/CurrentSelected.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/CurrentSelected.tsx
@@ -11,6 +11,7 @@ import { AcronymDictionary } from '../../../Presets/DataDict';
 import {
   InheritWidthGrid, CenterAlignedDiv, Title,
 } from '../../../Presets/StyledComponents';
+import { usePrivateProvLabel } from '../../Hooks/PrivateModeLabeling';
 
 const TinyFontButton = styled(Button)({
   fontSize: 'xx-small!important',
@@ -19,6 +20,7 @@ const TinyFontButton = styled(Button)({
 function CurrentSelected() {
   const store = useContext(Store);
   const { currentSelectedPatientGroup, currentSelectSet } = store.provenanceState;
+  const getLabel = usePrivateProvLabel();
 
   return (
     <InheritWidthGrid item>
@@ -28,6 +30,7 @@ function CurrentSelected() {
             <Title>Currently Selected</Title>
           </ListItem>
 
+          {/** Currently Selected Cases */}
           {currentSelectedPatientGroup.length > 0
             ? (
               <ListItem alignItems="flex-start" style={{ width: '100%' }}>
@@ -43,12 +46,13 @@ function CurrentSelected() {
               </ListItem>
             )
             : null}
-
+          {/** Currently Selected Attributes */}
           {currentSelectSet.map((selectSet: SelectSet) => (
             <ListItem key={`${selectSet.setName}selected`}>
+              {/** primary = Attribute Name.  secondary = attribute values, different values for private mode. */}
               <ListItemText
                 primary={AcronymDictionary[selectSet.setName as keyof typeof AcronymDictionary] ? AcronymDictionary[selectSet.setName as keyof typeof AcronymDictionary] : selectSet.setName}
-                secondary={selectSet.setValues.sort().join(', ')}
+                secondary={store.configStore.privateMode ? selectSet.setValues.sort().join(', ') : selectSet.setValues.map((value) => getLabel(value, selectSet.setName)).sort().join(', ')}
               />
               <ListItemSecondaryAction>
                 <IconButton onClick={() => { store.interactionStore.clearSet(selectSet.setName); }}>

--- a/frontend/src/Components/Utilities/LeftToolBox/CurrentSelected.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/CurrentSelected.tsx
@@ -52,7 +52,13 @@ function CurrentSelected() {
               {/** primary = Attribute Name.  secondary = attribute values, different values for private mode. */}
               <ListItemText
                 primary={AcronymDictionary[selectSet.setName as keyof typeof AcronymDictionary] ? AcronymDictionary[selectSet.setName as keyof typeof AcronymDictionary] : selectSet.setName}
-                secondary={store.configStore.privateMode ? selectSet.setValues.sort().join(', ') : selectSet.setValues.map((value) => getLabel(value, selectSet.setName)).sort().join(', ')}
+                secondary={
+                  selectSet
+                    .setValues
+                    .map((value) => getLabel(value, selectSet.setName))
+                    .sort()
+                    .join(', ')
+                }
               />
               <ListItemSecondaryAction>
                 <IconButton onClick={() => { store.interactionStore.clearSet(selectSet.setName); }}>


### PR DESCRIPTION
### Does this PR close any open issues?

### Give a longer description of what this PR addresses and why it's needed
**Before:** Selected Cases appeared as '-----' when off of private mode.
After: Flipped


### Provide pictures/videos of the behavior before and after these changes (optional)
Now only secret on 'private mode':
<img width="501" alt="Screenshot 2025-05-20 at 7 10 29 PM" src="https://github.com/user-attachments/assets/06247cd8-2b19-4670-8194-0b3aaaef1af9" />
<img width="389" alt="Screenshot 2025-05-20 at 7 10 40 PM" src="https://github.com/user-attachments/assets/089d1bd7-72dc-48d0-9e8d-73ca82c21703" />


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?
