### PR TITLE
Fix: Multiple Procedure Selection Logic (#391)

### DIFF
--- a/frontend/src/Interfaces/Store.ts
+++ b/frontend/src/Interfaces/Store.ts
@@ -116,7 +116,7 @@ export class RootStore {
 
       // If there are selected procedures, filter cases based on the selected procedures
       const procedureFiltered = hasAnyProcedure && !this.provenanceState.proceduresSelection.some((procedure) => {
-        const patientCodes = d.ALL_CODES.split(/\s*,\s*/);
+        const patientCodes = d.ALL_CODES.split(',');
 
         // Sub-procedures selected (overlapList)
         if (procedure.overlapList && procedure.overlapList.length > 0) {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #391

### Give a longer description of what this PR addresses and why it's needed
When selecting multiple procedures and sub-procedures, it was using AND logic instead of OR logic.

Ex: (CABG OR ECMO) was actually filtering with CABG _AND_ ECMO. This has been fixed for procedures and sub-procedures.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
<img width="121" alt="Screenshot 2025-05-20 at 9 26 35 PM" src="https://github.com/user-attachments/assets/f840a0fd-f014-43ac-9541-34fdd55c3734" />


After:
<img width="147" alt="Screenshot 2025-05-20 at 9 26 16 PM" src="https://github.com/user-attachments/assets/30dd30dd-81f8-4cb6-85eb-82836d7e8783" />


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?