### PR TITLE
Fix: Normalize & Truncate Provider Names

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,8 @@
         "mobx": "^6.3.2",
         "mobx-react": "^7.2.0",
         "mui-nested-menu": "^3.4.0",
+        "parse-full-name": "^1.2.6",
+        "@types/parse-full-name": "^1.2.5",
         "pdfast": "^0.2.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",

--- a/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.css
+++ b/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.css
@@ -1,0 +1,7 @@
+.y-axis-label-ellipsis {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    user-select: none;
+    text-align: right;
+    overflow: hidden;
+}

--- a/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.tsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react';
 import Store from '../../../Interfaces/Store';
 import { largeFontSize, regularFontSize } from '../../../Presets/Constants';
 import { AttributePlotTooltip } from './AttributePlots/AttributePlotTooltip';
+import './HeatMapAxisY.css';
 
 /**
  * Creates a y axis of hoverable rowLabels for a heatmap.
@@ -23,20 +24,30 @@ function HeatMapAxisY({
   return (
     <g className="axes-y" transform={`translate(${position[0]}, ${position[1]})`}>
       {/** For every row label, create and position it with a tooltip */}
-      {rowLabels.map(({ y, text, tooltipLabel }, i) => (
-        <AttributePlotTooltip key={i} title={tooltipLabel}>
-          <text
-            className="y-axis-label"
-            x={width}
-            y={y}
-            fontSize={store.configStore.largeFont ? largeFontSize : regularFontSize}
-            style={{ userSelect: 'none' }}
-            textAnchor="end"
-          >
-            {text}
-          </text>
-        </AttributePlotTooltip>
-      ))}
+      {rowLabels.map(({ y, text, tooltipLabel }, i) => {
+        const textHeight = store.configStore.largeFont ? largeFontSize * 1.5 : regularFontSize * 1.5;
+        return (
+          <AttributePlotTooltip key={i} title={tooltipLabel}>
+            <foreignObject
+              x={0}
+              y={y - textHeight / 2}
+              width={width}
+              height={textHeight}
+              style={{ overflow: 'visible' }}
+            >
+              <div
+                className="y-axis-label-ellipsis"
+                style={{
+                  fontSize: store.configStore.largeFont ? largeFontSize : regularFontSize,
+                  justifyContent: 'right',
+                }}
+              >
+                {text}
+              </div>
+            </foreignObject>
+          </AttributePlotTooltip>
+        );
+      })}
     </g>
   );
 }

--- a/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.tsx
@@ -17,9 +17,10 @@ type Props = {
     dimensionHeight: number;
     attributePlotTotalWidth: number;
     yAxisVar: Aggregation;
+    labelMaxChars?: number;
 };
-function HeatMapAxis({
-  svg, currentOffset, attributePlotTotalWidth, xVals, dimensionHeight, yAxisVar,
+function HeatMapAxisY({
+  svg, currentOffset, attributePlotTotalWidth, xVals, dimensionHeight, yAxisVar, labelMaxChars = 17,
 }: Props) {
   const store = useContext(Store);
   const aggregationScale = useCallback(() => AggregationScaleGenerator(xVals, dimensionHeight, currentOffset), [dimensionHeight, xVals, currentOffset]);
@@ -29,6 +30,10 @@ function HeatMapAxis({
 
   // Gets the provider name depending on the private mode setting
   const getLabel = usePrivateProvLabel();
+  const truncate = (label: string) => {
+    if (label.length <= labelMaxChars) return label;
+    return `${label.slice(0, labelMaxChars - 3)}...`;
+  };
 
   svgSelection
     .select('.axes-y')
@@ -45,7 +50,7 @@ function HeatMapAxis({
     .attr('pointer-events', 'none')
     .style('user-select', 'none')
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .text((d: any) => getLabel(d, yAxisVar));
+    .text((d: any) => truncate(getLabel(d, yAxisVar)));
 
   return (
     <g className="axes-y">
@@ -54,4 +59,4 @@ function HeatMapAxis({
   );
 }
 
-export default observer(HeatMapAxis);
+export default observer(HeatMapAxisY);

--- a/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisY.tsx
@@ -1,60 +1,42 @@
-import { axisLeft, select } from 'd3';
-import { RefObject, useCallback, useContext } from 'react';
+import React from 'react';
 import { observer } from 'mobx-react';
-import {
-  CaseRectWidth, largeFontSize, regularFontSize,
-} from '../../../Presets/Constants';
-import { AggregationScaleGenerator } from '../../../HelperFunctions/Scales';
-import { Offset } from '../../../Interfaces/Types/OffsetType';
 import Store from '../../../Interfaces/Store';
-import { Aggregation } from '../../../Presets/DataDict';
-import { usePrivateProvLabel } from '../../Hooks/PrivateModeLabeling';
+import { largeFontSize, regularFontSize } from '../../../Presets/Constants';
+import { AttributePlotTooltip } from './AttributePlots/AttributePlotTooltip';
 
-type Props = {
-    svg: RefObject<SVGSVGElement>;
-    currentOffset: Offset;
-    xVals: string[];
-    dimensionHeight: number;
-    attributePlotTotalWidth: number;
-    yAxisVar: Aggregation;
-    labelMaxChars?: number;
-};
+/**
+ * Creates a y axis of hoverable rowLabels for a heatmap.
+ * @param position - The [x, y] position of the axis.
+ * @param width - The width of the axis.
+ * @param rowLabels - An array of rowLabel objects. Each rowLabel has `y` position, `text` label, and `tooltipLabel`.
+ */
 function HeatMapAxisY({
-  svg, currentOffset, attributePlotTotalWidth, xVals, dimensionHeight, yAxisVar, labelMaxChars = 17,
-}: Props) {
-  const store = useContext(Store);
-  const aggregationScale = useCallback(() => AggregationScaleGenerator(xVals, dimensionHeight, currentOffset), [dimensionHeight, xVals, currentOffset]);
-
-  const svgSelection = select(svg.current);
-  const aggregationLabel = axisLeft(aggregationScale());
-
-  // Gets the provider name depending on the private mode setting
-  const getLabel = usePrivateProvLabel();
-  const truncate = (label: string) => {
-    if (label.length <= labelMaxChars) return label;
-    return `${label.slice(0, labelMaxChars - 3)}...`;
-  };
-
-  svgSelection
-    .select('.axes-y')
-    .select('.y-axis')
-    .attr(
-      'transform',
-      `translate(${currentOffset.left + attributePlotTotalWidth}, 0)`,
-    )
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .call(aggregationLabel as any)
-    .selectAll('text')
-    .attr('font-size', store.configStore.largeFont ? largeFontSize : regularFontSize)
-    .attr('transform', `translate(-${CaseRectWidth + 2},0)`)
-    .attr('pointer-events', 'none')
-    .style('user-select', 'none')
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .text((d: any) => truncate(getLabel(d, yAxisVar)));
-
+  position,
+  width,
+  rowLabels,
+}: {
+  position: [number, number];
+  width: number;
+  rowLabels: { y: number; text: string; tooltipLabel: string }[];
+}) {
+  const store = React.useContext(Store);
   return (
-    <g className="axes-y">
-      <g className="y-axis" />
+    <g className="axes-y" transform={`translate(${position[0]}, ${position[1]})`}>
+      {/** For every row label, create and position it with a tooltip */}
+      {rowLabels.map(({ y, text, tooltipLabel }, i) => (
+        <AttributePlotTooltip key={i} title={tooltipLabel}>
+          <text
+            className="y-axis-label"
+            x={width}
+            y={y}
+            fontSize={store.configStore.largeFont ? largeFontSize : regularFontSize}
+            style={{ userSelect: 'none' }}
+            textAnchor="end"
+          >
+            {text}
+          </text>
+        </AttributePlotTooltip>
+      ))}
     </g>
   );
 }

--- a/frontend/src/Components/Charts/HeatMap/HeatMap.tsx
+++ b/frontend/src/Components/Charts/HeatMap/HeatMap.tsx
@@ -33,21 +33,21 @@ const outputGradientLegend = (showZero: boolean, dimensionWidth: number) => {
 };
 
 type Props = {
-    dimensionWidth: number;
-    dimensionHeight: number;
-    xAxisVar: BloodComponent;
-    yAxisVar: Aggregation;
-    chartId: string;
-    data: HeatMapDataPoint[];
-    svg: React.RefObject<SVGSVGElement>;
-    attributePlotData: AttributePlotData<'Violin' | 'BarChart' | 'Basic'>[];
-    attributePlotTotalWidth: number;
-    interventionDate?: number;
-    secondaryData?: HeatMapDataPoint[];
-    secondaryAttributePlotData?: AttributePlotData<'Violin' | 'BarChart' | 'Basic'>[];
-    firstTotal: number;
-    secondTotal: number;
-    outcomeComparison?: Outcome;
+  dimensionWidth: number;
+  dimensionHeight: number;
+  xAxisVar: BloodComponent;
+  yAxisVar: Aggregation;
+  chartId: string;
+  data: HeatMapDataPoint[];
+  svg: React.RefObject<SVGSVGElement>;
+  attributePlotData: AttributePlotData<'Violin' | 'BarChart' | 'Basic'>[];
+  attributePlotTotalWidth: number;
+  interventionDate?: number;
+  secondaryData?: HeatMapDataPoint[];
+  secondaryAttributePlotData?: AttributePlotData<'Violin' | 'BarChart' | 'Basic'>[];
+  firstTotal: number;
+  secondTotal: number;
+  outcomeComparison?: Outcome;
 };
 
 function HeatMap({
@@ -94,7 +94,7 @@ function HeatMap({
   function rowSelected(attribute: string, value: string) {
     return interactionStore.selectedAttributes
       ?.some(([attrName, attrValue]) => attrName === attribute && attrValue === value)
-    ?? false;
+      ?? false;
   }
 
   // Sets the selected attribute in the store.
@@ -130,15 +130,19 @@ function HeatMap({
 
   // Y-axis labels ---------------------------
   const getLabel = usePrivateProvLabel();
-  // Position of the Y Axis Labels
-  const yAxisPos: [number, number] = [attributePlotTotalWidth + currentOffset.left / 2, 0];
-  const maxChars = 16;
+
+  // Position of the Y Axis
+  const yAxisWidthOffset = CaseRectWidth * 2;
+  const yAxisPos: [number, number] = [attributePlotTotalWidth + (currentOffset.left / 2) - yAxisWidthOffset, 0];
+
+  // Width of the Y Axis
+  const yAxisWidth = yAxisWidthOffset * 1.5;
   // Y Axis Labels have a y position, text, and tooltip text.
   const yAxisLabels = xVals.map((val) => {
     const y = (scale(val) ?? 0) + band / 2 + padding;
     return {
       y,
-      text: getLabel(val, yAxisVar, maxChars),
+      text: getLabel(val, yAxisVar),
       tooltipLabel: getLabel(val, yAxisVar, undefined, false),
     };
   });
@@ -154,9 +158,9 @@ function HeatMap({
         <svg style={{ height: `${svgHeight}px`, width: '100%' }} ref={innerSvg}>
           <g>
             {data.map((dataPoint, idx) => {
-            // Calculate vertical placement and height for each primary row
+              // Calculate vertical placement and height for each primary row
               const rowY = (aggregationScale()(dataPoint.aggregateAttribute) || 0)
-              + (secondaryData ? aggregationScale().bandwidth() * 0.5 : 0);
+                + (secondaryData ? aggregationScale().bandwidth() * 0.5 : 0);
 
               // For this row, is the row selected or hovered?
               const isSelected = rowSelected(yAxisVar, dataPoint.aggregateAttribute);
@@ -185,7 +189,7 @@ function HeatMap({
                     valueScaleDomain={JSON.stringify(valueScale().domain())}
                     valueScaleRange={JSON.stringify(valueScale().range())}
                     dataPoint={dataPoint}
-                  // Now rendered at y=0 within this transformed group
+                    // Now rendered at y=0 within this transformed group
                     howToTransform="translate(0,0)"
                   />
                   <ChartG currentOffset={currentOffset} attributePlotTotalWidth={attributePlotTotalWidth}>
@@ -205,7 +209,7 @@ function HeatMap({
             {secondaryData ? secondaryData.map((dataPoint, idx) => {
               // Calculate vertical placement and height for each primary row
               const rowY = (aggregationScale()(dataPoint.aggregateAttribute) || 0)
-              + (aggregationScale().bandwidth() * 0.5);
+                + (aggregationScale().bandwidth() * 0.5);
 
               // For this secondary row, is the row selected or hovered?
               const isSelected = rowSelected(yAxisVar, dataPoint.aggregateAttribute);
@@ -246,7 +250,7 @@ function HeatMap({
             {/** Row labels rendered on top */}
             <HeatMapAxisY
               position={yAxisPos}
-              width={CaseRectWidth}
+              width={yAxisWidth}
               rowLabels={yAxisLabels}
             />
           </g>

--- a/frontend/src/Components/Hooks/PrivateModeLabeling.tsx
+++ b/frontend/src/Components/Hooks/PrivateModeLabeling.tsx
@@ -7,18 +7,11 @@ import Store from '../../Interfaces/Store';
  *
  * @param label - The label to be transformed (string or number).
  * @param attribute - The attribute associated with the label.
- * @param charLimit - Optional character limit for the label.
  * @param normalizeProvNames - If truthy, skip normalizing provider names.
  * @returns The transformed label.
  */
-export function usePrivateProvLabel(): (label: string | number, attribute: string, charLimit?: number, normalizeProvNames?: boolean) => string {
+export function usePrivateProvLabel(): (label: string | number, attribute: string, normalizeProvNames?: boolean) => string {
   const store = useContext(Store);
-
-  // Truncates the label to a specified character limit, adding ellipsis if necessary
-  const truncateLabel = useCallback((label: string, charLimit: number): string => {
-    if (label.length <= charLimit) return label;
-    return `${label.slice(0, charLimit - 3)}...`;
-  }, []);
 
   // Normalizes provider names by parsing full names and formatting them
   const normalizeProviderLabel = (label: string): string => {
@@ -72,8 +65,6 @@ export function usePrivateProvLabel(): (label: string | number, attribute: strin
     }
 
     // Truncate the label if requested.
-    return charLimit
-      ? truncateLabel(outputLabel, charLimit)
-      : outputLabel;
-  }, [store.configStore.privateMode, store.providerMapping, truncateLabel]);
+    return outputLabel;
+  }, [store.configStore.privateMode, store.providerMapping]);
 }

--- a/frontend/src/Components/Hooks/PrivateModeLabeling.tsx
+++ b/frontend/src/Components/Hooks/PrivateModeLabeling.tsx
@@ -1,4 +1,5 @@
 import { useContext, useCallback } from 'react';
+import { parseFullName } from 'parse-full-name';
 import Store from '../../Interfaces/Store';
 
 /**
@@ -6,32 +7,73 @@ import Store from '../../Interfaces/Store';
  *
  * @param label - The label to be transformed (string or number).
  * @param attribute - The attribute associated with the label.
- * @returns The transformed label. If private mode is enabled, provider names are not revealed.
+ * @param charLimit - Optional character limit for the label.
+ * @param normalizeProvNames - If truthy, skip normalizing provider names.
+ * @returns The transformed label.
  */
-export function usePrivateProvLabel(): (label: string | number, attribute: string) => string {
+export function usePrivateProvLabel(): (label: string | number, attribute: string, charLimit?: number, normalizeProvNames?: boolean) => string {
   const store = useContext(Store);
 
-  // Convert the label to a provider name or id depending on private mode setting.
-  return useCallback((label: string | number, attribute: string): string => {
-    // If the attribute is not a provider, return the label as is.
-    if (!attribute.includes('PROV_ID')) {
-      return String(label);
+  // Truncates the label to a specified character limit, adding ellipsis if necessary
+  const truncateLabel = useCallback((label: string, charLimit: number): string => {
+    if (label.length <= charLimit) return label;
+    return `${label.slice(0, charLimit - 3)}...`;
+  }, []);
+
+  // Normalizes provider names by parsing full names and formatting them
+  const normalizeProviderLabel = (label: string): string => {
+    const name = parseFullName(label, undefined, true);
+    let normalizedLabel = label;
+    // If 'doctor', replace with 'Dr.'
+    (['title', 'first', 'last'] as const).forEach((part) => {
+      if (name[part] && name[part]!.toLowerCase() === 'doctor') {
+        name[part] = 'Dr.';
+      }
+    });
+
+    // If there's a title and last name, use "Title Last"
+    if (name.last && name.title) {
+      normalizedLabel = `${name.title} ${name.last}`;
+    } else if (name.first && name.last) {
+      // If there's a first and last name, use "Last, First"
+      normalizedLabel = `${name.last}, ${name.first}`;
+    } else if (name.last) {
+      normalizedLabel = name.last;
+    }
+    return normalizedLabel;
+  };
+
+  // Main function to get the label based on private mode and attribute
+  return useCallback((
+    label: string | number,
+    attribute: string,
+    charLimit?: number,
+    normalizeProvNames: boolean = true,
+  ): string => {
+    // Is this label is a provider
+    const isProv = attribute.includes('PROV_ID');
+    let outputLabel = String(label);
+
+    // If the label is a provider
+    if (isProv) {
+      // If in private mode, map the name to a provider ID. If no ID found, return label as is.
+      if (store.configStore.privateMode) {
+        const found = Object.entries(store.providerMapping)
+          .find(([, value]) => value === outputLabel);
+        outputLabel = found?.[0] ?? outputLabel;
+      } else {
+        // If not private mode, map the provider ID to a name. If no name found, return label as is.
+        outputLabel = store.providerMapping[outputLabel] ?? outputLabel;
+        // Normalize provider names, if requested
+        if (normalizeProvNames) {
+          outputLabel = normalizeProviderLabel(outputLabel);
+        }
+      }
     }
 
-    // If private mode is enabled, return the provider id.
-    if (store.configStore.privateMode) {
-      const labelStr = String(label);
-
-      // If the label is an id, find the corresponding provider name.
-      const id = Object.entries(store.providerMapping)
-        .find(([_, value]) => value === labelStr);
-
-      // if we found one, return it, otherwise return the label itself
-      return id?.[0] ?? labelStr;
-    }
-
-    // If private mode is disabled, return the provider name.
-    const name = store.providerMapping[label];
-    return name ?? String(label);
-  }, [store.configStore.privateMode, store.providerMapping]);
+    // Truncate the label if requested.
+    return charLimit
+      ? truncateLabel(outputLabel, charLimit)
+      : outputLabel;
+  }, [store.configStore.privateMode, store.providerMapping, truncateLabel]);
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1330,6 +1330,11 @@
   dependencies:
     undici-types "~6.20.0"
 
+"@types/parse-full-name@^1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@types/parse-full-name/-/parse-full-name-1.2.5.tgz#fb72bd34941942f75744ff1b3b3c9d4bfc2d6ba2"
+  integrity sha512-WUF23RA1BnYknAOlmeECS08OPWuySK1xaC15Gik10lcL+TUnhAWkAvEEaqRaKETXHp8y5TpzUqhIvaW12fqI0g==
+
 "@types/parse-json@^4.0.0":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
@@ -3522,6 +3527,11 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse-full-name@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/parse-full-name/-/parse-full-name-1.2.6.tgz#97e2643c0167b79ca404dab254ea79e89b025704"
+  integrity sha512-uIaENXJFmZfzulBndhHJayi7ZEifJ1bXKaWYmySa04EmMX7eIcsufiAgWTYiJqWRa/Sq7JWPGtCIXFAoUfF7gw==
 
 parse-json@^5.0.0:
   version "5.2.0"


### PR DESCRIPTION
### Does this PR close any open issues?

### Give a longer description of what this PR addresses and why it's needed

1. Truncates Provider Names which were overlapping on UW's implementation
2. Tooltip hover functionality to see provider name
3. Provider display name (as opposed to tooltip) is _normalized_ in the format: [title, last, first] and catches many exceptions.

### Provide pictures/videos of the behavior before and after these changes (optional)

**Normalizing Names:**
Here is a test dataset of randomly generated names in all sorts of formats and casings
- Some include titles like 'Doctor' 'Dr.' or no title at all. 
- Some are first, last others are last, first.
The names are normalized on display, but made fully available by tooltip hover.

https://github.com/user-attachments/assets/37887db8-11f5-4ba1-aaa8-fc6a9088e9bf


### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?
