### PR TITLE
Fix: 'Only' Procedure Filter

### DIFF
--- a/frontend/src/Components/Utilities/LeftToolBox/LeftToolBox.tsx
+++ b/frontend/src/Components/Utilities/LeftToolBox/LeftToolBox.tsx
@@ -26,11 +26,17 @@ function LeftToolBox() {
 
       // Process the result into the data type required.
       const result = procedureInput.result.map((procedure) => {
-        const procedureOverlapList = Object.keys(procedure.overlapList).map((subProcedureName) => ({
-          procedureName: subProcedureName,
-          count: procedure.overlapList[subProcedureName],
-          codes: procedureInput.result.find((p) => p.procedureName === subProcedureName)?.procedureCodes || [],
-        }));
+        console.log('Procedure:', procedure);
+
+        // Overlap List
+        const procedureOverlapList = Object.keys(procedure.overlapList).map((subProcedureName) => {
+          // Strip "Only " prefix for lookup
+          const baseName = subProcedureName.startsWith('Only ') ? subProcedureName.replace(/^Only\s+/, '') : subProcedureName;
+          return {
+            procedureName: subProcedureName,
+            count: procedure.overlapList[subProcedureName],
+            codes: procedureInput.result.find((p) => p.procedureName === baseName)?.procedureCodes || [],
+          }});
         procedureOverlapList.sort((a, b) => {
           if (a.procedureName.includes('Only')) {
             return -1;


### PR DESCRIPTION
### Does this PR close any open issues?

### Give a longer description of what this PR addresses and why it's needed

Before: 
When clicking on a sub-procedure filter that says 'Only' (Example: 'Only CABG'), the filter would remove all cases.

After:
The sub-procedure filter that says 'Only' now filters correctly for 'Only [procedure]'.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [x] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

