### PR TITLE
Fix: Cell Salvage Heatmap Labels (#425)

### DIFF
--- a/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisX.tsx
+++ b/frontend/src/Components/Charts/ChartAccessories/HeatMapAxisX.tsx
@@ -33,7 +33,7 @@ function HeatMapAxis({
   let valueLabel;
   if (isValueScaleBand) {
     valueLabel = axisBottom(valueScale() as ScaleBand<string>)
-    // eslint-disable-next-line no-nested-ternary, @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line no-nested-ternary, @typescript-eslint/no-explicit-any
       .tickFormat((d, i) => (xAxisVar === 'CELL_SAVER_ML' ? CELL_SAVER_TICKS[i] : (d === BloodProductCap[xAxisVar as BloodComponent] as any ? `${d}+` : d)));
   } else {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -61,7 +61,11 @@ function HeatMapAxis({
     .attr('font-size', store.configStore.largeFont ? largeFontSize : regularFontSize)
     .attr('text-anchor', 'middle')
     .attr('transform', `translate(${attributePlotTotalWidth},0)`)
-    .text(() => (AcronymDictionary[xAxisVar] ? AcronymDictionary[xAxisVar] : xAxisVar));
+    .text(() => (
+      xAxisVar === 'CELL_SAVER_ML'
+        ? 'Cell Salvage Volume (Hundreds of mL)'
+        : (AcronymDictionary[xAxisVar] ? AcronymDictionary[xAxisVar] : xAxisVar)
+    ));
 
   svgSelection
     .select('.y-label')

--- a/frontend/src/Presets/Constants.ts
+++ b/frontend/src/Presets/Constants.ts
@@ -42,7 +42,7 @@ export const OffsetDict = {
   } as Offset,
 };
 
-export const CELL_SAVER_TICKS = ['0', '0-1h', '1h-2h', '2h-3h', '3h-4h', '4h-5h', '5h-6h', '6h-7h', '7h-8h', '8h-9h', '9h-1k', '1k+'];
+export const CELL_SAVER_TICKS = ['0', '0-1h', '1-2h', '2-3h', '3-4h', '4-5h', '5-6h', '6-7h', '7-8h', '8-9h', '9-1k', '1k+'];
 
 export const MIN_HEATMAP_BANDWIDTH = (secondaryData: unknown) => (secondaryData ? 40 : 20);
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #425 

### Give a longer description of what this PR addresses and why it's needed
Read #425 raised by Jing Zhang, U.W.

Labels for cell salvage heatmap are now 1,2,3..N+ in units of 100mL

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
<img width="1031" alt="Screenshot 2025-07-03 at 2 42 29 PM" src="https://github.com/user-attachments/assets/faa643a4-863b-4744-93e4-1d97b65b16ab" />

After:
<img width="884" alt="Screenshot 2025-07-03 at 7 24 07 PM" src="https://github.com/user-attachments/assets/269da8ef-cfc6-4d29-a90c-c6c4f625a902" />




### Have you added or updated relevant tests?
- [ ] Yes
- [X] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [X] No changes are needed

### Are there any additional TODOs before this PR is ready to go?