### PR TITLE
Fix: Outcome Filters

### DIFF
--- a/frontend/src/Interfaces/Store.ts
+++ b/frontend/src/Interfaces/Store.ts
@@ -77,7 +77,7 @@ export class RootStore {
       }
       // Outcome filter
       if (this.provenanceState.outcomeFilter.length > 0) {
-        // Return false instead of direct return statement to allow for AND logic
+        // Return false if outcome filter fails, but continue checking other filters if it passes
         if (this.provenanceState.outcomeFilter.some((outcome) => !d[outcome])) {
           return false;
         }


### PR DESCRIPTION
### Does this PR close any open issues?
N/A

### Give a longer description of what this PR addresses and why it's needed
Before:
- When clicking outcome filter such as 'Ventilator over 24hr' more cases were appearing than before.
- This is because other filters were not being applied on top.

After: 
- As we expect, clicking an outcome such as 'Ventilator over 24hr', only cases that received Vent > 24hr will show (less cases, subset).
