### PR TITLE
Add 0 RBC to heatmap

### DIFF
--- a/frontend/src/Components/Views/ExploreView/Charts/ExploreTable.tsx
+++ b/frontend/src/Components/Views/ExploreView/Charts/ExploreTable.tsx
@@ -75,7 +75,7 @@ const getFormattedValue = (
   return `${prefix}${formattedValue}${space}${suffix}`;
 };
 
-const HEATMAP_COLS = ['percent_1_rbc', 'percent_2_rbc', 'percent_3_rbc', 'percent_4_rbc', 'percent_above_5_rbc'];
+const HEATMAP_COLS = ['percent_0_rbc', 'percent_1_rbc', 'percent_2_rbc', 'percent_3_rbc', 'percent_4_rbc', 'percent_above_5_rbc'];
 
 // When adding column, infer column type from attribute
 const inferColumnType = (key: string, data: ExploreTableData): ExploreTableColumn['type'] => {

--- a/frontend/src/Components/Views/ExploreView/ExploreView.tsx
+++ b/frontend/src/Components/Views/ExploreView/ExploreView.tsx
@@ -111,6 +111,12 @@ export function ExploreView() {
             title: 'Cases',
           },
           {
+            colVar: 'percent_0_rbc',
+            aggregation: aggregation as 'sum' | 'avg',
+            type: 'heatmap',
+            title: '0 RBC',
+          },
+          {
             colVar: 'percent_1_rbc',
             aggregation: aggregation as 'sum' | 'avg',
             type: 'heatmap',

--- a/frontend/src/Components/Views/ExploreView/PresetStateCards.ts
+++ b/frontend/src/Components/Views/ExploreView/PresetStateCards.ts
@@ -40,6 +40,12 @@ export const presetStateCards: PresetGroup[] = [
                 title: 'Cases',
               },
               {
+                colVar: 'percent_0_rbc',
+                aggregation: 'avg',
+                type: 'heatmap',
+                title: '0 RBC',
+              },
+              {
                 colVar: 'percent_1_rbc',
                 aggregation: 'avg',
                 type: 'heatmap',

--- a/frontend/src/Types/application.ts
+++ b/frontend/src/Types/application.ts
@@ -645,7 +645,7 @@ export type ScatterPlotData = ScatterChartSeries[];
 // --- Explore Table ---
 
 // Column options
-const RBC_COUNTS = ['1', '2', '3', '4', 'above_5'] as const;
+const RBC_COUNTS = ['0', '1', '2', '3', '4', 'above_5'] as const;
 const RBC_PERCENT_OPTIONS = RBC_COUNTS.map((count) => ({
   value: `percent_${count}_rbc`,
   label: count === 'above_5' ? '≥5 RBC' : `${count} RBC`,


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #512 

### Give a longer description of what this PR addresses and why it's needed
<img width="2194" height="647" alt="Screenshot 2026-02-18 at 11 58 15 AM" src="https://github.com/user-attachments/assets/4e628487-0593-4fe2-bef2-90677e48f2ad" />

Adds 0 RBC to heatmap. Unsurprisingly, the majority of cases are 0 RBC in our synthetic dataset.
