### PR TITLE
Remove background rendering of all tabs

### DIFF
--- a/frontend/src/Shell/Shell.tsx
+++ b/frontend/src/Shell/Shell.tsx
@@ -355,14 +355,7 @@ export const Shell = observer(() => {
       <AppShell.Main>
         <Container fluid mt="xs">
           {/** Display content of active tab */}
-          {TABS.map((tab) => (
-            <Box
-              key={tab.key}
-              style={{ display: store.state.ui.activeTab === tab.key ? 'block' : 'none' }}
-            >
-              {tab.content}
-            </Box>
-          ))}
+          {TABS.find((tab) => tab.key === store.state.ui.activeTab)?.content}
         </Container>
       </AppShell.Main>
 


### PR DESCRIPTION
### Does this PR close any open issues?
N/A

### Give a longer description of what this PR addresses and why it's needed
**Before:** All tabs were rendered simultaneously and hidden via `display: none`

**After:**  Only render the active tab's content instead of rendering all tabs and hiding them with CSS

### Provide pictures/videos of the behavior before and after these changes (optional)


### Have you added or updated relevant tests?
- [ ] Yes
- [x] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [x] No changes are needed

### Are there any additional TODOs before this PR is ready to go?
N/A