### PR TITLE
Fix dashboard aggregates for boolean metrics

### DIFF
--- a/frontend/src/Store/Store.ts
+++ b/frontend/src/Store/Store.ts
@@ -44,6 +44,21 @@ export const MANUAL_INFINITY = Number.MAX_SAFE_INTEGER;
 
 const sqlString = (value: string) => `'${value.replace(/'/g, "''")}'`;
 const safeIdPattern = /^[A-Za-z0-9_-]+$/;
+const DASHBOARD_BOOLEAN_Y_AXIS_VARS = new Set([
+  'death',
+  'vent',
+  'stroke',
+  'ecmo',
+  'b12',
+  'iron',
+  'antifibrinolytic',
+]);
+
+const dashboardMetricSqlExpression = (yAxisVar: string) => (
+  DASHBOARD_BOOLEAN_Y_AXIS_VARS.has(yAxisVar)
+    ? `CASE WHEN ${yAxisVar} THEN 1 ELSE 0 END`
+    : yAxisVar
+);
 
 export const DEFAULT_CHART_LAYOUTS: { [key: string]: Layout[] } = {
   main: [
@@ -1000,7 +1015,7 @@ export class RootStore {
             `SUM(${baseUnit}) AS ${aggregation}_${yAxisVar}_den`,
           ];
         }
-        return `${aggFn}(${yAxisVar}) AS ${aggregation}_${yAxisVar}`;
+        return `${aggFn}(${dashboardMetricSqlExpression(yAxisVar)}) AS ${aggregation}_${yAxisVar}`;
       })
     ));
 
@@ -1185,11 +1200,12 @@ export class RootStore {
               `;
         }
         // Default: Other stats
+        const metricExpression = dashboardMetricSqlExpression(yAxisVar);
         return `
               ${aggFn}(CASE WHEN dsch_dtm >= '${currentPeriodStart.toISOString()}' AND dsch_dtm <= '${latestDate.toISOString()}'
-                THEN ${yAxisVar} ELSE NULL END) AS ${yAxisVar}_current_${aggregation},
+                THEN ${metricExpression} ELSE NULL END) AS ${yAxisVar}_current_${aggregation},
               ${aggFn}(CASE WHEN dsch_dtm >= '${comparisonPeriodStart.toISOString()}' AND dsch_dtm <= '${comparisonPeriodEnd.toISOString()}'
-                THEN ${yAxisVar} ELSE NULL END) AS ${yAxisVar}_comparison_${aggregation}
+                THEN ${metricExpression} ELSE NULL END) AS ${yAxisVar}_comparison_${aggregation}
             `;
       }),
     ].join(',\n');
@@ -1249,7 +1265,7 @@ export class RootStore {
       }
       // Default: Other stats
       sparklineSelects.push(
-        `${aggFn}(${yAxisVar}) AS ${aggregation}_${yAxisVar}`,
+        `${aggFn}(${dashboardMetricSqlExpression(yAxisVar)}) AS ${aggregation}_${yAxisVar}`,
       );
     });
 


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
This PR fixes dashboard stat cards and charts for boolean metrics by converting boolean values to numeric 1/0 expressions before aggregation. DuckDB does not support AVG(BOOLEAN), which caused combined dashboard stat queries to fail and left unrelated stat cards, such as RBC Units sum, stuck in a loading state.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Have you added or updated relevant tests?
- [ ] Yes
- [ ] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [ ] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
