### PR TITLE
Add CMI Weighted Discharge Benchmark Metrics

### DIFF
--- a/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.tsx
+++ b/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.tsx
@@ -1489,17 +1489,18 @@ const ExploreTable = observer(({ chartConfig }: { chartConfig: ExploreTableConfi
   }, [rowsWithGroups, chartConfig.twoValsPerRow, chartConfig.rowVar, numericFilters, defaultNumericFilter, textFilters, hoverState, setHoveredValue, chartConfig.groupByVar, getSubRowOpacity, buildGroupFilter, groupValues, fromLabel, sortStatus.columnAccessor]);
 
   // Data Table Columns -------
+  const columnVars = `${chartConfig.columns.map((c) => c.colVar).join(',')}|${chartConfig.groupByVar || ''}`;
+  const columnStorageKey = `ExploreTable-${chartConfig.chartId}-${columnVars}`;
   const columnDefs = useMemo(
     () => generateColumnDefs(chartConfig.columns),
     [generateColumnDefs, chartConfig.columns],
   );
   const { effectiveColumns, resetColumnsOrder } = useDataTableColumns<ExploreTableRow>({
-    key: `ExploreTable-${chartConfig.chartId}`,
+    key: columnStorageKey,
     columns: columnDefs,
   });
 
-  // Reset column order when columns change
-  const columnVars = `${chartConfig.columns.map((c) => c.colVar).join(',')}|${chartConfig.groupByVar || ''}`;
+  // Reset column order when columns change while the table is mounted.
   const prevColumnVars = useRef(columnVars);
 
   useEffect(() => {
@@ -1646,7 +1647,7 @@ const ExploreTable = observer(({ chartConfig }: { chartConfig: ExploreTableConfi
             sorted: <IconChevronUp size={14} className="active-sort-icon" />,
             unsorted: <IconSelector size={14} />,
           }}
-          storeColumnsKey={`ExploreTable-${chartConfig.chartId}`}
+          storeColumnsKey={columnStorageKey}
           columns={effectiveColumns}
           style={useMemo(() => ({ fontStyle: 'italic' }), [])}
           onRowClick={undefined}

--- a/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.tsx
+++ b/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.tsx
@@ -1161,11 +1161,11 @@ const ExploreTable = observer(({ chartConfig }: { chartConfig: ExploreTableConfi
         accessor: colVar,
         title: displayTitle,
         titleClassName: `${isActiveSort ? 'sorted-column-header' : ''} ${isActiveFilter ? 'filtered-column-header' : ''}`.trim() || undefined,
-        draggable: colVar !== 'cases' && !(colConfigs.filter((c) => c.type === 'text').length === 1 && colConfigs[0].colVar === colVar),
+        draggable: !['cases', 'visit_count'].includes(colVar) && !(colConfigs.filter((c) => c.type === 'text').length === 1 && colConfigs[0].colVar === colVar),
         resizable: false,
         sortable: true,
         noWrap: true,
-        width: colVar === 'cases' ? 90 : colVar === 'salvage_savings' ? 250 : colVar === 'total_cost' ? 400 : (colVar === 'attending_provider' || (colConfigs.filter((c) => c.type === 'text').length === 1 && colConfigs[0].colVar === colVar)) ? 175 : undefined,
+        width: ['cases', 'visit_count'].includes(colVar) ? 90 : colVar === 'salvage_savings' ? 250 : colVar === 'total_cost' ? 400 : (colVar === 'attending_provider' || (colConfigs.filter((c) => c.type === 'text').length === 1 && colConfigs[0].colVar === colVar)) ? 175 : undefined,
         filtering: isActiveFilter,
         filter: filterComponent,
         footer: type === 'violin' ? violinFooter : (type === 'numeric' || type === 'heatmap') ? (

--- a/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.tsx
+++ b/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.tsx
@@ -58,6 +58,11 @@ export const getGroupColor = (groupByVar: string | undefined, groupVal: string, 
   const outcomes = ['death', 'stroke', 'vent', 'ecmo'];
   const nonOutcomes = ['b12', 'iron', 'antifibrinolytic'];
 
+  if (groupByVar === 'overall_units_adherent') {
+    if (groupVal === '1' || groupVal === 'true') return '#2f9e44';
+    if (groupVal === '0' || groupVal === 'false') return '#c92a2a';
+  }
+
   if (outcomes.includes(groupByVar)) {
     if (groupVal === '1' || groupVal === 'true') return '#D81B60'; // Red
     if (groupVal === '0' || groupVal === 'false') return '#1E88E5'; // Blue
@@ -73,6 +78,10 @@ export const getGroupColor = (groupByVar: string | undefined, groupVal: string, 
 
 export const getGroupLabel = (groupByVar: string | undefined, val: string) => {
   if (!groupByVar) return val;
+  if (groupByVar === 'overall_units_adherent') {
+    if (val === '1' || val === 'true') return 'Guideline Adherent';
+    return 'Not Guideline Adherent';
+  }
   if (['death', 'stroke', 'vent', 'ecmo', 'b12', 'iron', 'antifibrinolytic'].includes(groupByVar)) {
     const label = ExploreTableGroupByOptions.find((o) => o.value === groupByVar)?.label || val;
     if (val === '1' || val === 'true') return label;
@@ -882,7 +891,7 @@ const ExploreTable = observer(({ chartConfig }: { chartConfig: ExploreTableConfi
 
     // Filter noise for boolean vars: keep only '0' and '1' or 'true' and 'false'
     let result = Array.from(values);
-    if (groupByVar && ['death', 'stroke', 'vent', 'ecmo', 'b12', 'iron', 'antifibrinolytic'].includes(groupByVar)) {
+    if (groupByVar && ['death', 'stroke', 'vent', 'ecmo', 'b12', 'iron', 'antifibrinolytic', 'overall_units_adherent'].includes(groupByVar)) {
       result = result.filter((v) => ['0', '1', 'true', 'false'].includes(v));
     }
     return result.sort().reverse(); // Show '1'/'true' on top, '0'/'false' on bottom

--- a/frontend/src/Components/Views/DepartmentView/DepartmentView.tsx
+++ b/frontend/src/Components/Views/DepartmentView/DepartmentView.tsx
@@ -141,6 +141,12 @@ export function DepartmentView() {
             title: groupLabel,
           },
           {
+            colVar: 'visit_count',
+            aggregation: 'sum',
+            type: 'numeric',
+            title: 'Visits',
+          },
+          {
             colVar: 'cases',
             aggregation: 'sum',
             type: 'numeric',
@@ -184,6 +190,12 @@ export function DepartmentView() {
             aggregation: 'none',
             type: 'text',
             title: groupLabel,
+          },
+          {
+            colVar: 'visit_count',
+            aggregation: 'sum',
+            type: 'numeric',
+            title: 'Visits',
           },
           {
             colVar: 'cases',

--- a/frontend/src/Components/Views/DepartmentView/PresetStateCards.ts
+++ b/frontend/src/Components/Views/DepartmentView/PresetStateCards.ts
@@ -24,7 +24,7 @@ export const presetStateCards: PresetGroup[] = [
         chartConfigs: [
           {
             chartId: 'preset-overview-department',
-            title: 'Blood Product Utilization per Surgeon',
+            title: 'Blood Product Utilization per Provider',
             chartType: 'exploreTable',
             rowVar: 'attending_provider',
             columns: [
@@ -32,7 +32,7 @@ export const presetStateCards: PresetGroup[] = [
                 colVar: 'attending_provider',
                 aggregation: 'none',
                 type: 'text',
-                title: 'Surgeon',
+                title: 'Provider',
               },
               {
                 colVar: 'visit_count',
@@ -488,7 +488,7 @@ export const presetStateCards: PresetGroup[] = [
     groupLabel: 'Cost / Savings',
     options: [
       {
-        question: 'What are the costs of blood products transfused intraoperatively by surgeon?',
+        question: 'What are the costs of blood products transfused intraoperatively by provider?',
         Icon: IconCoin,
         chartConfigs: [
           {

--- a/frontend/src/Components/Views/DepartmentView/PresetStateCards.ts
+++ b/frontend/src/Components/Views/DepartmentView/PresetStateCards.ts
@@ -35,6 +35,12 @@ export const presetStateCards: PresetGroup[] = [
                 title: 'Surgeon',
               },
               {
+                colVar: 'visit_count',
+                aggregation: 'sum',
+                type: 'numeric',
+                title: 'Visits',
+              },
+              {
                 colVar: 'cases',
                 aggregation: 'sum',
                 type: 'numeric',
@@ -147,6 +153,12 @@ export const presetStateCards: PresetGroup[] = [
                 title: 'Provider',
               },
               {
+                colVar: 'visit_count',
+                aggregation: 'sum',
+                type: 'numeric',
+                title: 'Visits',
+              },
+              {
                 colVar: 'cases',
                 aggregation: 'sum',
                 type: 'numeric',
@@ -247,6 +259,12 @@ export const presetStateCards: PresetGroup[] = [
                 aggregation: 'none',
                 type: 'text',
                 title: 'Provider',
+              },
+              {
+                colVar: 'visit_count',
+                aggregation: 'sum',
+                type: 'numeric',
+                title: 'Visits',
               },
               {
                 colVar: 'cases',
@@ -353,6 +371,12 @@ export const presetStateCards: PresetGroup[] = [
                 title: 'Death',
               },
               {
+                colVar: 'visit_count',
+                aggregation: 'sum',
+                type: 'numeric',
+                title: 'Visits',
+              },
+              {
                 colVar: 'cases',
                 aggregation: 'sum',
                 type: 'numeric',
@@ -433,6 +457,12 @@ export const presetStateCards: PresetGroup[] = [
                 title: 'Cell Salvage (mL)',
               },
               {
+                colVar: 'visit_count',
+                aggregation: 'sum',
+                type: 'numeric',
+                title: 'Visits',
+              },
+              {
                 colVar: 'cases',
                 aggregation: 'sum',
                 type: 'numeric',
@@ -478,6 +508,12 @@ export const presetStateCards: PresetGroup[] = [
                 aggregation: 'none',
                 type: 'text',
                 title: 'Provider',
+              },
+              {
+                colVar: 'visit_count',
+                aggregation: 'sum',
+                type: 'numeric',
+                title: 'Visits',
               },
               {
                 colVar: 'cases',

--- a/frontend/src/Store/Store.ts
+++ b/frontend/src/Store/Store.ts
@@ -90,6 +90,34 @@ const dashboardMetricSqlExpression = (yAxisVar: string) => (
     : yAxisVar
 );
 
+const GUIDELINE_ADHERENCE_GROUP_VAR = 'overall_units_adherent';
+const GUIDELINE_ADHERENCE_UNIT_COLUMNS: Record<string, string> = {
+  rbc_units: 'rbc_units_adherent',
+  ffp_units: 'ffp_units_adherent',
+  plt_units: 'plt_units_adherent',
+  cryo_units: 'cryo_units_adherent',
+};
+
+const guidelineAdherenceEligibleUnitsExpression = (qualifier = '') => (
+  Object.keys(GUIDELINE_ADHERENCE_UNIT_COLUMNS)
+    .map((col) => `COALESCE(${qualifier}${col}, 0)`)
+    .join(' + ')
+);
+
+const guidelineAdherenceBucketUnitsExpression = (isAdherentExpression: string, qualifier = '') => {
+  const eligibleUnits = guidelineAdherenceEligibleUnitsExpression(qualifier);
+  const adherentUnits = `COALESCE(${qualifier}overall_units_adherent, 0)`;
+
+  return `CASE WHEN ${isAdherentExpression} THEN ${adherentUnits} ELSE GREATEST((${eligibleUnits}) - ${adherentUnits}, 0) END`;
+};
+
+const guidelineAdherenceProductExpression = (metric: string, isAdherentExpression: string, qualifier = '') => {
+  const adherentMetric = GUIDELINE_ADHERENCE_UNIT_COLUMNS[metric];
+  if (!adherentMetric) return null;
+
+  return `CASE WHEN ${isAdherentExpression} THEN COALESCE(${qualifier}${adherentMetric}, 0) ELSE GREATEST(COALESCE(${qualifier}${metric}, 0) - COALESCE(${qualifier}${adherentMetric}, 0), 0) END`;
+};
+
 export const DEFAULT_CHART_LAYOUTS: { [key: string]: Layout[] } = {
   main: [
     {
@@ -1984,6 +2012,14 @@ export class RootStore {
       if (config.chartType === 'exploreTable') {
         // Configuration of table (rowVar, columns, aggregation, etc.)
         const tableConfig = config as ExploreTableConfig;
+        const isGuidelineAdherenceGroup = tableConfig.groupByVar === GUIDELINE_ADHERENCE_GROUP_VAR;
+        const adherenceGroupExpr = 'adherence_group.is_guideline_adherent';
+        const adherenceGroupJoinClause = isGuidelineAdherenceGroup
+          ? 'CROSS JOIN (VALUES (TRUE), (FALSE)) AS adherence_group(is_guideline_adherent)'
+          : '';
+        const adherenceGroupWhereClause = isGuidelineAdherenceGroup
+          ? `WHERE ${guidelineAdherenceBucketUnitsExpression(adherenceGroupExpr, 'v.')} > 0`
+          : '';
         const internalRowKeyExpr = tableConfig.rowVar === 'attending_provider'
           ? 'v.attending_provider_id'
           : `v.${tableConfig.rowVar}`;
@@ -2001,22 +2037,35 @@ export class RootStore {
           const caseIdExpr = tableConfig.rowVar === 'attending_provider'
             ? 'provider_cases.case_id'
             : 'surgery_cases.case_id';
+          const caseAdherenceGroupExpr = 'case_adherence_group.is_guideline_adherent';
+          const caseAdherenceJoinClause = isGuidelineAdherenceGroup
+            ? 'CROSS JOIN (VALUES (TRUE), (FALSE)) AS case_adherence_group(is_guideline_adherent)'
+            : '';
           const caseSource = tableConfig.rowVar === 'attending_provider'
             ? `${needsVisitCaseJoin ? `(
               SELECT UNNEST([surgeon_prov_id, anesth_prov_id]) AS prov_id, case_id, visit_no
               FROM filteredSurgeryCases
             ) provider_cases
-            INNER JOIN filteredVisits visit_cases ON visit_cases.visit_no = provider_cases.visit_no` : `(
+            INNER JOIN filteredVisits visit_cases ON visit_cases.visit_no = provider_cases.visit_no
+            ${caseAdherenceJoinClause}` : `(
               SELECT UNNEST([surgeon_prov_id, anesth_prov_id]) AS prov_id, case_id
               FROM filteredSurgeryCases
             ) provider_cases`}`
             : `filteredSurgeryCases surgery_cases
-            INNER JOIN filteredVisits visit_cases ON visit_cases.visit_no = surgery_cases.visit_no`;
-          const caseWhereClause = tableConfig.rowVar === 'attending_provider'
-            ? 'WHERE provider_cases.prov_id IS NOT NULL'
+            INNER JOIN filteredVisits visit_cases ON visit_cases.visit_no = surgery_cases.visit_no
+            ${caseAdherenceJoinClause}`;
+          const caseWhereConditions = [];
+          if (tableConfig.rowVar === 'attending_provider') {
+            caseWhereConditions.push('provider_cases.prov_id IS NOT NULL');
+          }
+          if (isGuidelineAdherenceGroup) {
+            caseWhereConditions.push(`${guidelineAdherenceBucketUnitsExpression(caseAdherenceGroupExpr, 'visit_cases.')} > 0`);
+          }
+          const caseWhereClause = caseWhereConditions.length > 0
+            ? `WHERE ${caseWhereConditions.join(' AND ')}`
             : '';
           const caseGroupExpr = tableConfig.groupByVar
-            ? `visit_cases.${tableConfig.groupByVar}`
+            ? (isGuidelineAdherenceGroup ? caseAdherenceGroupExpr : `visit_cases.${tableConfig.groupByVar}`)
             : null;
           const caseSelects = [`${caseRowExpr} AS row_key`];
           const caseGroupBys = [caseRowExpr];
@@ -2027,7 +2076,7 @@ export class RootStore {
           if (caseGroupExpr) {
             caseSelects.push(`${caseGroupExpr} AS group_key`);
             caseGroupBys.push(caseGroupExpr);
-            caseJoinConditions.push(`pc.group_key = v.${tableConfig.groupByVar}`);
+            caseJoinConditions.push(isGuidelineAdherenceGroup ? `pc.group_key = ${adherenceGroupExpr}` : `pc.group_key = v.${tableConfig.groupByVar}`);
           }
 
           caseCountExpr = 'COALESCE(MAX(pc.case_count), 0)';
@@ -2131,6 +2180,14 @@ export class RootStore {
             return;
           }
 
+          const guidelineAdherenceProduct = isGuidelineAdherenceGroup
+            ? guidelineAdherenceProductExpression(colVar, adherenceGroupExpr, 'v.')
+            : null;
+          if (guidelineAdherenceProduct && (colAggregation === 'avg' || colAggregation === 'sum')) {
+            columnClauses.push(`${aggFn}(${guidelineAdherenceProduct}) AS ${colVar}`);
+            return;
+          }
+
           // Standard numeric & boolean fields
           const booleanFields = ['death', 'vent', 'stroke', 'ecmo', 'b12', 'iron', 'antifibrinolytic'];
           if (booleanFields.includes(colVar) && (colAggregation === 'avg' || colAggregation === 'sum')) {
@@ -2182,7 +2239,7 @@ export class RootStore {
 
         // Add secondary grouping variable if present
         if (tableConfig.groupByVar) {
-          const secondaryGroupCol = `v.${tableConfig.groupByVar}`;
+          const secondaryGroupCol = isGuidelineAdherenceGroup ? adherenceGroupExpr : `v.${tableConfig.groupByVar}`;
           groupByParts.push(secondaryGroupCol);
           orderByParts.push(secondaryGroupCol);
           columnClauses.splice(1, 0, `${secondaryGroupCol} AS _group_val`);
@@ -2196,7 +2253,9 @@ export class RootStore {
           SELECT
             ${columnClauses.join(',\n            ')}
           FROM filteredVisits v
+          ${adherenceGroupJoinClause}
           ${caseJoinClause}
+          ${adherenceGroupWhereClause}
           GROUP BY ${groupByClause}
           ORDER BY ${orderByClause};
         `;

--- a/frontend/src/Store/Store.ts
+++ b/frontend/src/Store/Store.ts
@@ -2070,6 +2070,12 @@ export class RootStore {
             return;
           }
 
+          // Special case: visits
+          if (colVar === 'visit_count') {
+            columnClauses.push(`COUNT(DISTINCT v.visit_no) AS ${colVar}`);
+            return;
+          }
+
           // Special case: attending_provider as non-row column
           if (colVar === 'attending_provider') {
             const expr = this.uiState.isInPrivateMode

--- a/frontend/src/Store/Store.ts
+++ b/frontend/src/Store/Store.ts
@@ -44,6 +44,32 @@ export const MANUAL_INFINITY = Number.MAX_SAFE_INTEGER;
 
 const sqlString = (value: string) => `'${value.replace(/'/g, "''")}'`;
 const safeIdPattern = /^[A-Za-z0-9_-]+$/;
+const cmiAdjustedBenchmarkNumerators: Record<string, string> = {
+  transfusions_per_cmi_visit: 'overall_units',
+  rbc_units_per_cmi_visit: 'rbc_units',
+  ffp_units_per_cmi_visit: 'ffp_units',
+  plt_units_per_cmi_visit: 'plt_units',
+  cryo_units_per_cmi_visit: 'cryo_units',
+  whole_units_per_cmi_visit: 'whole_units',
+  cell_saver_ml_per_cmi_visit: 'cell_saver_ml',
+};
+
+const cmiAdjustedBenchmarkExpression = (metric: string, condition?: string) => {
+  const numerator = cmiAdjustedBenchmarkNumerators[metric];
+  if (!numerator) return null;
+
+  const numeratorExpression = condition
+    ? `CASE WHEN ${condition} THEN ${numerator} ELSE 0 END`
+    : numerator;
+  const cmiExpression = condition
+    ? `CASE WHEN ${condition} THEN ms_drg_weight ELSE NULL END`
+    : 'ms_drg_weight';
+  const visitExpression = condition
+    ? `CASE WHEN ${condition} THEN visit_no ELSE NULL END`
+    : 'visit_no';
+
+  return `CAST(SUM(${numeratorExpression}) AS DOUBLE) / NULLIF(AVG(${cmiExpression}) * COUNT(DISTINCT ${visitExpression}), 0)`;
+};
 
 export const DEFAULT_CHART_LAYOUTS: { [key: string]: Layout[] } = {
   main: [
@@ -984,6 +1010,10 @@ export class RootStore {
             `${aggFn}(COALESCE(rbc_units_cost, 0) + COALESCE(plt_units_cost, 0) + COALESCE(ffp_units_cost, 0) + COALESCE(cryo_units_cost, 0) + COALESCE(whole_cost, 0) + COALESCE(cell_saver_cost, 0)) AS ${aggregation}_total_blood_product_cost`,
           ];
         }
+        const adjustedBenchmarkExpression = cmiAdjustedBenchmarkExpression(yAxisVar);
+        if (adjustedBenchmarkExpression) {
+          return `${adjustedBenchmarkExpression} AS ${aggregation}_${yAxisVar}`;
+        }
         // Special case: case mix index
         if (yAxisVar === 'case_mix_index') {
           return `AVG(ms_drg_weight) AS ${aggregation}_case_mix_index`;
@@ -1152,6 +1182,16 @@ export class RootStore {
                   THEN rbc_units_cost + plt_units_cost + ffp_units_cost + cryo_units_cost + whole_cost + cell_saver_cost ELSE NULL END) AS total_blood_product_cost_comparison_${aggregation}
               `;
         }
+        const currentPeriodCondition = `dsch_dtm >= '${currentPeriodStart.toISOString()}' AND dsch_dtm <= '${latestDate.toISOString()}'`;
+        const comparisonPeriodCondition = `dsch_dtm >= '${comparisonPeriodStart.toISOString()}' AND dsch_dtm <= '${comparisonPeriodEnd.toISOString()}'`;
+        const currentBenchmarkExpression = cmiAdjustedBenchmarkExpression(yAxisVar, currentPeriodCondition);
+        if (currentBenchmarkExpression) {
+          const comparisonBenchmarkExpression = cmiAdjustedBenchmarkExpression(yAxisVar, comparisonPeriodCondition);
+          return `
+                ${currentBenchmarkExpression} AS ${yAxisVar}_current_${aggregation},
+                ${comparisonBenchmarkExpression} AS ${yAxisVar}_comparison_${aggregation}
+              `;
+        }
         // Exception: Case mix index
         if (yAxisVar === 'case_mix_index') {
           return `
@@ -1222,6 +1262,13 @@ export class RootStore {
       if (yAxisVar === 'total_blood_product_cost') {
         sparklineSelects.push(
           `${aggFn}(rbc_units_cost + plt_units_cost + ffp_units_cost + cryo_units_cost + whole_cost + cell_saver_cost) AS ${aggregation}_total_blood_product_cost`,
+        );
+        return;
+      }
+      const adjustedBenchmarkExpression = cmiAdjustedBenchmarkExpression(yAxisVar);
+      if (adjustedBenchmarkExpression) {
+        sparklineSelects.push(
+          `${adjustedBenchmarkExpression} AS ${aggregation}_${yAxisVar}`,
         );
         return;
       }
@@ -2285,6 +2332,11 @@ export class RootStore {
         statSelects.push(
           `${aggFn}(rbc_units_cost + plt_units_cost + ffp_units_cost + cryo_units_cost + whole_cost + cell_saver_cost) AS ${aggregation}_total_blood_product_cost`,
         );
+        return;
+      }
+      const adjustedBenchmarkExpression = cmiAdjustedBenchmarkExpression(yAxisVar);
+      if (adjustedBenchmarkExpression) {
+        statSelects.push(`${adjustedBenchmarkExpression} AS ${aggregation}_${yAxisVar}`);
         return;
       }
       if (yAxisVar === 'case_mix_index') {

--- a/frontend/src/Store/Store.ts
+++ b/frontend/src/Store/Store.ts
@@ -54,19 +54,22 @@ const cmiAdjustedBenchmarkNumerators: Record<string, string> = {
   cell_saver_ml_per_cmi_visit: 'cell_saver_ml',
 };
 
-const cmiAdjustedBenchmarkExpression = (metric: string, condition?: string) => {
+const cmiAdjustedBenchmarkExpression = (metric: string, condition?: string, qualifier = '') => {
   const numerator = cmiAdjustedBenchmarkNumerators[metric];
   if (!numerator) return null;
 
+  const qualifiedNumerator = `${qualifier}${numerator}`;
+  const qualifiedCmi = `${qualifier}ms_drg_weight`;
+  const qualifiedVisitNo = `${qualifier}visit_no`;
   const numeratorExpression = condition
-    ? `CASE WHEN ${condition} THEN ${numerator} ELSE 0 END`
-    : numerator;
+    ? `CASE WHEN ${condition} THEN ${qualifiedNumerator} ELSE 0 END`
+    : qualifiedNumerator;
   const cmiExpression = condition
-    ? `CASE WHEN ${condition} THEN ms_drg_weight ELSE NULL END`
-    : 'ms_drg_weight';
+    ? `CASE WHEN ${condition} THEN ${qualifiedCmi} ELSE NULL END`
+    : qualifiedCmi;
   const visitExpression = condition
-    ? `CASE WHEN ${condition} THEN visit_no ELSE NULL END`
-    : 'visit_no';
+    ? `CASE WHEN ${condition} THEN ${qualifiedVisitNo} ELSE NULL END`
+    : qualifiedVisitNo;
 
   return `CAST(SUM(${numeratorExpression}) AS DOUBLE) / NULLIF(AVG(${cmiExpression}) * COUNT(DISTINCT ${visitExpression}), 0)`;
 };
@@ -2095,6 +2098,13 @@ export class RootStore {
           // Special case: salvage_savings
           if (colVar === 'salvage_savings') {
             columnClauses.push(`${aggFn}(cell_saver_cost) AS salvage_savings`);
+            return;
+          }
+
+          // Special case: CMI weighted discharge benchmark metrics
+          const adjustedBenchmarkExpression = cmiAdjustedBenchmarkExpression(colVar, undefined, 'v.');
+          if (adjustedBenchmarkExpression) {
+            columnClauses.push(`${adjustedBenchmarkExpression} AS ${colVar}`);
             return;
           }
 

--- a/frontend/src/Types/application.ts
+++ b/frontend/src/Types/application.ts
@@ -528,6 +528,122 @@ export const CASE_MIX_INDEX = {
   decimals: { sum: 2, avg: 2 },
 };
 
+export const TRANSFUSIONS_PER_CMI_VISIT = {
+  value: 'transfusions_per_cmi_visit',
+  label: {
+    short: 'Adjusted Transfusions',
+    base: 'Transfusions / CMI Weighted Discharge',
+    sum: 'Transfusions / CMI Weighted Discharge',
+    avg: 'Transfusions / CMI Weighted Discharge',
+  },
+  units: {
+    sum: 'Units per CMI Weighted Discharge',
+    avg: 'Units per CMI Weighted Discharge',
+    sumShort: 'Units',
+    avgShort: 'Units',
+  },
+  decimals: { sum: 3, avg: 3 },
+} as const;
+
+export const BLOOD_PRODUCT_TRANSFUSIONS_PER_CMI_VISIT_OPTIONS = [
+  {
+    value: 'rbc_units_per_cmi_visit',
+    label: {
+      short: 'Adjusted RBCs',
+      base: 'RBC Units / CMI Weighted Discharge',
+      sum: 'RBC Units / CMI Weighted Discharge',
+      avg: 'RBC Units / CMI Weighted Discharge',
+    },
+    units: {
+      sum: 'RBC Units per CMI Weighted Discharge',
+      avg: 'RBC Units per CMI Weighted Discharge',
+      sumShort: 'Units',
+      avgShort: 'Units',
+    },
+    decimals: { sum: 3, avg: 3 },
+  },
+  {
+    value: 'ffp_units_per_cmi_visit',
+    label: {
+      short: 'Adjusted FFP',
+      base: 'FFP Units / CMI Weighted Discharge',
+      sum: 'FFP Units / CMI Weighted Discharge',
+      avg: 'FFP Units / CMI Weighted Discharge',
+    },
+    units: {
+      sum: 'FFP Units per CMI Weighted Discharge',
+      avg: 'FFP Units per CMI Weighted Discharge',
+      sumShort: 'Units',
+      avgShort: 'Units',
+    },
+    decimals: { sum: 3, avg: 3 },
+  },
+  {
+    value: 'plt_units_per_cmi_visit',
+    label: {
+      short: 'Adjusted Platelets',
+      base: 'Platelet Units / CMI Weighted Discharge',
+      sum: 'Platelet Units / CMI Weighted Discharge',
+      avg: 'Platelet Units / CMI Weighted Discharge',
+    },
+    units: {
+      sum: 'Platelet Units per CMI Weighted Discharge',
+      avg: 'Platelet Units per CMI Weighted Discharge',
+      sumShort: 'Units',
+      avgShort: 'Units',
+    },
+    decimals: { sum: 3, avg: 3 },
+  },
+  {
+    value: 'cryo_units_per_cmi_visit',
+    label: {
+      short: 'Adjusted Cryo',
+      base: 'Cryo Units / CMI Weighted Discharge',
+      sum: 'Cryo Units / CMI Weighted Discharge',
+      avg: 'Cryo Units / CMI Weighted Discharge',
+    },
+    units: {
+      sum: 'Cryo Units per CMI Weighted Discharge',
+      avg: 'Cryo Units per CMI Weighted Discharge',
+      sumShort: 'Units',
+      avgShort: 'Units',
+    },
+    decimals: { sum: 3, avg: 3 },
+  },
+  {
+    value: 'whole_units_per_cmi_visit',
+    label: {
+      short: 'Adjusted Whole Blood',
+      base: 'Whole Blood Units / CMI Weighted Discharge',
+      sum: 'Whole Blood Units / CMI Weighted Discharge',
+      avg: 'Whole Blood Units / CMI Weighted Discharge',
+    },
+    units: {
+      sum: 'Whole Blood Units per CMI Weighted Discharge',
+      avg: 'Whole Blood Units per CMI Weighted Discharge',
+      sumShort: 'Units',
+      avgShort: 'Units',
+    },
+    decimals: { sum: 3, avg: 3 },
+  },
+  {
+    value: 'cell_saver_ml_per_cmi_visit',
+    label: {
+      short: 'Adjusted Cell Salvage',
+      base: 'Cell Salvage Volume / CMI Weighted Discharge',
+      sum: 'Cell Salvage Volume / CMI Weighted Discharge',
+      avg: 'Cell Salvage Volume / CMI Weighted Discharge',
+    },
+    units: {
+      sum: 'mL per CMI Weighted Discharge',
+      avg: 'mL per CMI Weighted Discharge',
+      sumShort: 'mL',
+      avgShort: 'mL',
+    },
+    decimals: { sum: 3, avg: 3 },
+  },
+] as const;
+
 // Costs -----------------------------------------------------------
 export const DEFAULT_UNIT_COSTS: Record<Cost, number> = {
   rbc_units_cost: 200,
@@ -588,6 +704,8 @@ export const dashboardYAxisOptions = [
   OVERALL_BLOOD_PRODUCT_COST,
   VISIT_COUNT,
   CASE_MIX_INDEX,
+  TRANSFUSIONS_PER_CMI_VISIT,
+  ...BLOOD_PRODUCT_TRANSFUSIONS_PER_CMI_VISIT_OPTIONS,
 ];
 export const dashboardYAxisVars = dashboardYAxisOptions.map((opt) => opt.value);
 

--- a/frontend/src/Types/application.ts
+++ b/frontend/src/Types/application.ts
@@ -770,13 +770,12 @@ export const BLOOD_PRODUCT_COLOR_THEME: Record<string, string> = {
 
 // Explore View ----------------------------------------------------
 // Aggregation options for explore view
-const _AGGREGATIONS = ['surgeon_prov_id', 'anesth_prov_id', 'year', 'quarter'] as const;
+const _AGGREGATIONS = ['attending_provider', 'year', 'quarter'] as const;
 export type Aggregation = typeof _AGGREGATIONS[number];
 
 // --- Cost bar charts TODO: Change to Explore Table ---
 const CostAggregations: { value: Aggregation; label: string }[] = [
-  { value: 'surgeon_prov_id', label: 'Surgeon ID' },
-  { value: 'anesth_prov_id', label: 'Anesthesiologist ID' },
+  { value: 'attending_provider', label: 'Provider' },
   { value: 'year', label: 'Year' },
   { value: 'quarter', label: 'Quarter' },
 ];
@@ -791,6 +790,7 @@ export type CostChartConfig = ChartConfig<typeof costXAxisVars[number], typeof c
 
 // TOOD: Update or remove CostBarData type
 export interface CostBarDatum extends Record<Cost, number> {
+  attending_provider?: string;
   surgeon_prov_id?: string;
   anesth_prov_id?: string;
   year?: string | number;

--- a/frontend/src/Types/application.ts
+++ b/frontend/src/Types/application.ts
@@ -1050,6 +1050,14 @@ export const ExploreTableColumnOptionsGrouped = [
         },
         decimals: 0,
       },
+      {
+        value: 'visit_count',
+        label: 'Visits',
+        units: {
+          sum: 'visits', avg: '% of visits', sumShort: ' Visits', avgShort: ' Visits',
+        },
+        decimals: 0,
+      },
     ],
   },
 ];

--- a/frontend/src/Types/application.ts
+++ b/frontend/src/Types/application.ts
@@ -941,6 +941,23 @@ export const ExploreTableColumnOptionsGrouped = [
     })),
   },
   {
+    group: 'CMI Weighted Discharge',
+    items: [
+      TRANSFUSIONS_PER_CMI_VISIT,
+      ...BLOOD_PRODUCT_TRANSFUSIONS_PER_CMI_VISIT_OPTIONS,
+    ].map((opt) => ({
+      value: opt.value,
+      label: opt.label.base,
+      units: {
+        sum: opt.units.sum,
+        avg: opt.units.avg,
+        sumShort: opt.units.sumShort,
+        avgShort: opt.units.avgShort,
+      },
+      decimals: opt.decimals,
+    })),
+  },
+  {
     group: 'Outcomes',
     items: OUTCOME_OPTIONS.map((opt) => ({
       value: opt.value,

--- a/frontend/src/Utils/dashboard.ts
+++ b/frontend/src/Utils/dashboard.ts
@@ -2,6 +2,8 @@ import {
   dashboardYAxisVars, BLOOD_COMPONENT_OPTIONS, OUTCOME_OPTIONS, COST_OPTIONS, OVERALL_BLOOD_PRODUCT_COST, GUIDELINE_ADHERENT_OPTIONS, OVERALL_GUIDELINE_ADHERENT, PROPHYL_MED_OPTIONS,
   AGGREGATION_OPTIONS,
   dashboardYAxisOptions,
+  TRANSFUSIONS_PER_CMI_VISIT,
+  BLOOD_PRODUCT_TRANSFUSIONS_PER_CMI_VISIT_OPTIONS,
 } from '../Types/application';
 
 /**
@@ -87,13 +89,17 @@ export function isMetricChangeGood(metricVar: typeof dashboardYAxisVars[number],
   const isBloodComponent = BLOOD_COMPONENT_OPTIONS.some((opt) => opt.value === metricVar);
   const isOutcome = OUTCOME_OPTIONS.some((opt) => opt.value === metricVar);
   const isCost = [...COST_OPTIONS, OVERALL_BLOOD_PRODUCT_COST].some((opt) => opt.value === metricVar);
+  const isCmiAdjustedBenchmark = [
+    TRANSFUSIONS_PER_CMI_VISIT,
+    ...BLOOD_PRODUCT_TRANSFUSIONS_PER_CMI_VISIT_OPTIONS,
+  ].some((opt) => opt.value === metricVar);
 
   // Guideline adherence and prophylactic medications - higher is better (positive change is good)
   const isAdherence = GUIDELINE_ADHERENT_OPTIONS.some((opt) => opt.value === metricVar);
   const isOverallAdherence = metricVar === OVERALL_GUIDELINE_ADHERENT.value;
   const isProphylMed = PROPHYL_MED_OPTIONS.some((opt) => opt.value === metricVar);
 
-  if (isBloodComponent || isOutcome || isCost) {
+  if (isBloodComponent || isOutcome || isCost || isCmiAdjustedBenchmark) {
   // For blood components and outcomes and costs, negative change is good
     return diffPercent < 0;
   }

--- a/frontend/src/Utils/humanReadableColsVals.ts
+++ b/frontend/src/Utils/humanReadableColsVals.ts
@@ -5,6 +5,8 @@ import {
   LAB_RESULTS,
   COSTS,
   TIME_AGGREGATION_OPTIONS,
+  TRANSFUSIONS_PER_CMI_VISIT,
+  BLOOD_PRODUCT_TRANSFUSIONS_PER_CMI_VISIT_OPTIONS,
 } from '../Types/application';
 import { BLOOD_COMPONENTS } from '../Types/bloodProducts';
 
@@ -104,6 +106,8 @@ export const formatStateDetailName = (key: string): string => {
     Object.values(GUIDELINE_ADHERENT),
     LAB_RESULTS,
     Object.values(COSTS),
+    TRANSFUSIONS_PER_CMI_VISIT,
+    BLOOD_PRODUCT_TRANSFUSIONS_PER_CMI_VISIT_OPTIONS,
   ].flat();
   const found = attributes.find((c) => c.value === key);
   if (found) {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #

### Give a longer description of what this PR addresses and why it's needed
Adds risk and volume adjusted benchmarking metrics to the dashboard and Explore stats.

New metrics include:

- Transfusions / CMI Weighted Discharge
- RBC Units / CMI Weighted Discharge
- FFP Units / CMI Weighted Discharge
- Platelet Units / CMI Weighted Discharge
- Cryo Units / CMI Weighted Discharge
- Whole Blood Units / CMI Weighted Discharge
- Cell Salvage Volume / CMI Weighted Discharge

The calculation uses each metric’s numerator divided by AVG(ms_drg_weight) * COUNT(DISTINCT visit_no), with divide-by-zero protection. Also updates formatting and metric change direction so lower adjusted rates are treated as better.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Have you added or updated relevant tests?
- [ ] Yes
- [ ] No changes are needed

### Have you added or updated relevant documentation?
- [ ] Yes
- [ ] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
