### PR TITLE
refactor filter range slider

### DIFF
--- a/frontend/src/Components/Toolbar/Filters/FilterRangeSlider.tsx
+++ b/frontend/src/Components/Toolbar/Filters/FilterRangeSlider.tsx
@@ -1,11 +1,7 @@
 import { RangeSliderValue, RangeSlider } from '@mantine/core';
 import { useObserver } from 'mobx-react-lite';
-import {
-  useContext, useMemo, useState, useEffect,
-} from 'react';
-import {
-  Store, ApplicationState,
-} from '../../../Store/Store';
+import { useContext } from 'react';
+import { Store, ApplicationState } from '../../../Store/Store';
 import { DEFAULT_DATA_COLOR } from '../../../Theme/mantineTheme';
 import { CELL_SAVER_ML } from '../../../Types/bloodProducts';
 
@@ -13,53 +9,38 @@ type NumberArrayKeys<T> = {
   [K in keyof T]: T[K] extends number[] ? K : never
 }[keyof T];
 
-export function FilterRangeSlider({ varName, paddingLeft, paddingRight }: { varName: NumberArrayKeys<ApplicationState['filterValues']>; paddingLeft?: number; paddingRight?: number }) {
+type FilterRangeSliderProps = {
+  varName: NumberArrayKeys<ApplicationState['filterValues']>;
+  paddingLeft?: number;
+  paddingRight?: number;
+};
+
+export function FilterRangeSlider({ varName, paddingLeft, paddingRight }: FilterRangeSliderProps) {
   const store = useContext(Store);
 
-  // Initial filter range & store filter range
   const [initialFilterMin, initialFilterMax] = store.initialFilterValues[varName];
-  const [currentFilterMin, currentFilterMax] = store.filterValues[varName];
+  const [filterMin, filterMax] = store.filterValues[varName];
+  const clampedMax = Math.min(store.clampedMax[varName], initialFilterMax);
+  const displayMax = Math.min(filterMax, clampedMax);
+  const isFilterActive = filterMin !== initialFilterMin || filterMax !== initialFilterMax;
 
-  // TODO redo the clamping logic
-  // Clamp slider max value to prevent outliers
-  const clampedMax = useMemo(
-    () => Math.min(store.clampedMax[varName], initialFilterMax),
-    [initialFilterMax, store.clampedMax, varName],
-  );
-
-  // Local state for smooth sliding
-  const [sliderValues, setSliderValues] = useState<[number, number]>(
-    [currentFilterMin, Math.min(currentFilterMax, clampedMax)],
-  );
-
-  // Sync with store updates
-  useEffect(
-    () => setSliderValues([currentFilterMin, Math.min(currentFilterMax, clampedMax)]),
-    [currentFilterMin, currentFilterMax, clampedMax],
-  );
-
-  const isFilterActive = useMemo(
-    () => sliderValues[0] !== initialFilterMin || sliderValues[1] !== clampedMax,
-    [sliderValues, initialFilterMin, clampedMax],
-  );
-
-  function setStoreFilterValue(v: RangeSliderValue) {
+  const handleCommit = (v: RangeSliderValue) => {
     store.setFilterValue(varName, [v[0], v[1] === clampedMax ? initialFilterMax : v[1]]);
-  }
+  };
 
   return useObserver(() => (
     <RangeSlider
-      value={sliderValues}
+      key={`${filterMin}-${filterMax}`}
+      defaultValue={[filterMin, displayMax]}
       size="sm"
-      onChange={setSliderValues}
-      onChangeEnd={(v) => setStoreFilterValue(v)}
+      onChangeEnd={handleCommit}
       min={initialFilterMin}
       max={clampedMax}
       step={varName === CELL_SAVER_ML ? 50 : 1}
       color={isFilterActive ? 'blue.6' : DEFAULT_DATA_COLOR}
       marks={[
         { value: initialFilterMin, label: `${initialFilterMin}` },
-        { value: clampedMax, label: `${clampedMax}` },
+        { value: clampedMax, label: `${clampedMax}${clampedMax < initialFilterMax ? '+' : ''}` },
       ]}
       minRange={0}
       mb="xl"

--- a/frontend/src/Components/Toolbar/Filters/FilterRangeSlider.tsx
+++ b/frontend/src/Components/Toolbar/Filters/FilterRangeSlider.tsx
@@ -1,6 +1,8 @@
 import { RangeSliderValue, RangeSlider } from '@mantine/core';
 import { useObserver } from 'mobx-react-lite';
-import { useContext } from 'react';
+import {
+  useContext, useEffect, useState,
+} from 'react';
 import { Store, ApplicationState } from '../../../Store/Store';
 import { DEFAULT_DATA_COLOR } from '../../../Theme/mantineTheme';
 import { CELL_SAVER_ML } from '../../../Types/bloodProducts';
@@ -23,6 +25,11 @@ export function FilterRangeSlider({ varName, paddingLeft, paddingRight }: Filter
   const clampedMax = Math.min(store.clampedMax[varName], initialFilterMax);
   const displayMax = Math.min(filterMax, clampedMax);
   const isFilterActive = filterMin !== initialFilterMin || filterMax !== initialFilterMax;
+  const [sliderValues, setSliderValues] = useState<[number, number]>([filterMin, displayMax]);
+
+  useEffect(() => {
+    setSliderValues([filterMin, displayMax]);
+  }, [displayMax, filterMax, filterMin]);
 
   const handleCommit = (v: RangeSliderValue) => {
     store.setFilterValue(varName, [v[0], v[1] === clampedMax ? initialFilterMax : v[1]]);
@@ -30,9 +37,9 @@ export function FilterRangeSlider({ varName, paddingLeft, paddingRight }: Filter
 
   return useObserver(() => (
     <RangeSlider
-      key={`${filterMin}-${filterMax}`}
-      defaultValue={[filterMin, displayMax]}
+      value={sliderValues}
       size="sm"
+      onChange={setSliderValues}
       onChangeEnd={handleCommit}
       min={initialFilterMin}
       max={clampedMax}


### PR DESCRIPTION
use store as source of truth, show + when it is clamped

Note the only change to current prod is it won't change the color of the slider until finish changing. which I think is fine. 
### Give a longer description of what this PR addresses and why it's needed


https://github.com/user-attachments/assets/3edd1c33-eece-4189-9422-1302b3b62d30


### Provide pictures/videos of the behavior before and after these changes (optional)


### Have you added or updated relevant tests?
- [ ] Yes
- [ ] No changes are needed



### Have you added or updated relevant documentation?
- [ ] Yes
- [ ] No changes are needed

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] ...
