### PR TITLE
Add 'No chart data' text to empty charts

### DIFF
--- a/frontend/src/Components/Views/DepartmentView/Charts/DumbbellChart.tsx
+++ b/frontend/src/Components/Views/DepartmentView/Charts/DumbbellChart.tsx
@@ -1567,7 +1567,24 @@ export function DumbbellChart({ chartConfig }: { chartConfig: DumbbellChartConfi
       </Flex>
 
       {/* Chart Area */}
-      <div style={{ flex: 1, minHeight: 0, width: '100%' }} ref={ref}>
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          width: '100%',
+          position: 'relative',
+        }}
+        ref={ref}
+      >
+        {processedData.length === 0 && store.exploreChartData[chartConfig.chartId] !== undefined && (
+          <Flex style={{ position: 'absolute', inset: 0, zIndex: 10 }} align="center" justify="center">
+            <Text c="dimmed" fs="italic" size="sm">
+              {store.totalFiltersAppliedCount > 0
+                ? 'No data available for this chart after filtering'
+                : 'No data available for this chart'}
+            </Text>
+          </Flex>
+        )}
         <Flex direction="row" h={height}>
           {/* Fixed Y Axis */}
           <div style={{ position: 'relative' }}>

--- a/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.css
+++ b/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.css
@@ -153,7 +153,3 @@
 }
 
 /* Highlight sort icon in blue when its column is active */
-.explore-table-data-table .active-sort-icon.active-sort-icon {
-  color: #1770B8;
-  stroke: #1770B8;
-}

--- a/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.tsx
+++ b/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.tsx
@@ -1623,6 +1623,28 @@ const ExploreTable = observer(({ chartConfig }: { chartConfig: ExploreTableConfi
 
       {/** Data Table */}
       <Box style={{ minHeight: 0, width: '100%', position: 'relative' }}>
+        {!isSyncing && chartData !== undefined && rowsWithGroups.length === 0 && (
+          <Flex
+            style={{
+              position: 'absolute',
+              top: 28,
+              bottom: 28,
+              left: 0,
+              right: 0,
+              zIndex: 10,
+            }}
+            align="center"
+            justify="center"
+          >
+            <Box px="lg" py="md" style={{ backgroundColor: 'rgba(255, 255, 255, 0.85)', borderRadius: 6 }}>
+              <Text c="dimmed" fs="italic" size="sm">
+                {store.totalFiltersAppliedCount > 0
+                  ? 'No data available for this chart after filtering'
+                  : 'No data available for this chart'}
+              </Text>
+            </Box>
+          </Flex>
+        )}
         <LoadingOverlay
           visible={isSyncing}
           zIndex={100}
@@ -1636,29 +1658,31 @@ const ExploreTable = observer(({ chartConfig }: { chartConfig: ExploreTableConfi
             ),
           }}
         />
-        <DataTable<ExploreTableRow>
-          className="explore-table-data-table"
-          rowClassName={() => (chartConfig.groupByVar ? 'fat-row' : '')}
-          borderRadius="sm"
-          pinFirstColumn
-          striped
-          withTableBorder={false}
-          highlightOnHover
-          withRowBorders={false}
-          highlightOnHoverColor={backgroundHoverColor}
-          records={rowsWithGroups}
-          idAccessor="_row_key"
-          sortStatus={sortStatus}
-          onSortStatusChange={setSortStatus}
-          sortIcons={{
-            sorted: <IconChevronUp size={14} className="active-sort-icon" />,
-            unsorted: <IconSelector size={14} />,
-          }}
-          storeColumnsKey={columnStorageKey}
-          columns={effectiveColumns}
-          style={useMemo(() => ({ fontStyle: 'italic' }), [])}
-          onRowClick={undefined}
-        />
+        {rowsWithGroups.length > 0 && (
+          <DataTable<ExploreTableRow>
+            className="explore-table-data-table"
+            rowClassName={() => (chartConfig.groupByVar ? 'fat-row' : '')}
+            borderRadius="sm"
+            pinFirstColumn
+            striped
+            withTableBorder={false}
+            highlightOnHover
+            withRowBorders={false}
+            highlightOnHoverColor={backgroundHoverColor}
+            records={rowsWithGroups}
+            idAccessor="_row_key"
+            sortStatus={sortStatus}
+            onSortStatusChange={setSortStatus}
+            sortIcons={{
+              sorted: <IconChevronUp size={14} className="active-sort-icon" />,
+              unsorted: <IconSelector size={14} />,
+            }}
+            storeColumnsKey={columnStorageKey}
+            columns={effectiveColumns}
+            style={useMemo(() => ({ fontStyle: 'italic' }), [])}
+            onRowClick={undefined}
+          />
+        )}
       </Box>
     </Stack>
   );

--- a/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.tsx
+++ b/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.tsx
@@ -1658,13 +1658,18 @@ const ExploreTable = observer(({ chartConfig }: { chartConfig: ExploreTableConfi
           columns={effectiveColumns}
           style={useMemo(() => ({ fontStyle: 'italic' }), [])}
           onRowClick={undefined}
-          noRecordsText={
-            !isSyncing && chartData !== undefined && rowsWithGroups.length === 0
-              ? (store.totalFiltersAppliedCount > 0
-                ? 'No data available for this chart after filtering'
-                : 'No data available for this chart')
-              : ''
-          }
+          minHeight={!isSyncing && chartData !== undefined && rowsWithGroups.length === 0 ? 150 : undefined}
+          emptyState={(() => {
+            if (isSyncing || chartData === undefined || rowsWithGroups.length > 0) return <span />;
+            const isFiltered = store.totalFiltersAppliedCount > 0
+              || Object.values(numericFilters).some((f) => f.query)
+              || Object.values(textFilters).some((f) => f.length > 0);
+            return (
+              <Text c="dimmed" fs="italic" size="sm">
+                {isFiltered ? 'No data available for this chart after filtering' : 'No data available for this chart'}
+              </Text>
+            );
+          })()}
         />
       </Box>
     </Stack>

--- a/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.tsx
+++ b/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.tsx
@@ -1623,28 +1623,6 @@ const ExploreTable = observer(({ chartConfig }: { chartConfig: ExploreTableConfi
 
       {/** Data Table */}
       <Box style={{ minHeight: 0, width: '100%', position: 'relative' }}>
-        {!isSyncing && chartData !== undefined && rowsWithGroups.length === 0 && (
-          <Flex
-            style={{
-              position: 'absolute',
-              top: 28,
-              bottom: 28,
-              left: 0,
-              right: 0,
-              zIndex: 10,
-            }}
-            align="center"
-            justify="center"
-          >
-            <Box px="lg" py="md" style={{ backgroundColor: 'rgba(255, 255, 255, 0.85)', borderRadius: 6 }}>
-              <Text c="dimmed" fs="italic" size="sm">
-                {store.totalFiltersAppliedCount > 0
-                  ? 'No data available for this chart after filtering'
-                  : 'No data available for this chart'}
-              </Text>
-            </Box>
-          </Flex>
-        )}
         <LoadingOverlay
           visible={isSyncing}
           zIndex={100}
@@ -1658,31 +1636,36 @@ const ExploreTable = observer(({ chartConfig }: { chartConfig: ExploreTableConfi
             ),
           }}
         />
-        {rowsWithGroups.length > 0 && (
-          <DataTable<ExploreTableRow>
-            className="explore-table-data-table"
-            rowClassName={() => (chartConfig.groupByVar ? 'fat-row' : '')}
-            borderRadius="sm"
-            pinFirstColumn
-            striped
-            withTableBorder={false}
-            highlightOnHover
-            withRowBorders={false}
-            highlightOnHoverColor={backgroundHoverColor}
-            records={rowsWithGroups}
-            idAccessor="_row_key"
-            sortStatus={sortStatus}
-            onSortStatusChange={setSortStatus}
-            sortIcons={{
-              sorted: <IconChevronUp size={14} className="active-sort-icon" />,
-              unsorted: <IconSelector size={14} />,
-            }}
-            storeColumnsKey={columnStorageKey}
-            columns={effectiveColumns}
-            style={useMemo(() => ({ fontStyle: 'italic' }), [])}
-            onRowClick={undefined}
-          />
-        )}
+        <DataTable<ExploreTableRow>
+          className="explore-table-data-table"
+          rowClassName={() => (chartConfig.groupByVar ? 'fat-row' : '')}
+          borderRadius="sm"
+          pinFirstColumn
+          striped
+          withTableBorder={false}
+          highlightOnHover
+          withRowBorders={false}
+          highlightOnHoverColor={backgroundHoverColor}
+          records={rowsWithGroups}
+          idAccessor="_row_key"
+          sortStatus={sortStatus}
+          onSortStatusChange={setSortStatus}
+          sortIcons={{
+            sorted: <IconChevronUp size={14} className="active-sort-icon" />,
+            unsorted: <IconSelector size={14} />,
+          }}
+          storeColumnsKey={columnStorageKey}
+          columns={effectiveColumns}
+          style={useMemo(() => ({ fontStyle: 'italic' }), [])}
+          onRowClick={undefined}
+          noRecordsText={
+            !isSyncing && chartData !== undefined && rowsWithGroups.length === 0
+              ? (store.totalFiltersAppliedCount > 0
+                ? 'No data available for this chart after filtering'
+                : 'No data available for this chart')
+              : ''
+          }
+        />
       </Box>
     </Stack>
   );

--- a/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.tsx
+++ b/frontend/src/Components/Views/DepartmentView/Charts/ExploreTable.tsx
@@ -919,6 +919,8 @@ const ExploreTable = observer(({ chartConfig }: { chartConfig: ExploreTableConfi
     }));
   }, [rows, chartConfig.groupByVar, getFilteredGroups]);
 
+  const tableStyle = useMemo(() => ({ fontStyle: 'italic' as const }), []);
+
   const handleRowChange = (value: string | null) => {
     if (!value) return;
 
@@ -1656,7 +1658,7 @@ const ExploreTable = observer(({ chartConfig }: { chartConfig: ExploreTableConfi
           }}
           storeColumnsKey={columnStorageKey}
           columns={effectiveColumns}
-          style={useMemo(() => ({ fontStyle: 'italic' }), [])}
+          style={tableStyle}
           onRowClick={undefined}
           minHeight={!isSyncing && chartData !== undefined && rowsWithGroups.length === 0 ? 150 : undefined}
           emptyState={(() => {

--- a/frontend/src/Components/Views/DepartmentView/Charts/ScatterPlot.tsx
+++ b/frontend/src/Components/Views/DepartmentView/Charts/ScatterPlot.tsx
@@ -929,7 +929,24 @@ export function ScatterPlot({ chartConfig }: { chartConfig: ScatterPlotConfig })
         </Flex>
 
         {/* Chart Area */}
-        <div style={{ flex: 1, minHeight: 0, width: '100%' }} ref={sizeRef}>
+        <div
+          style={{
+            flex: 1,
+            minHeight: 0,
+            width: '100%',
+            position: 'relative',
+          }}
+          ref={sizeRef}
+        >
+          {processedData.length === 0 && store.exploreChartData[chartConfig.chartId] !== undefined && (
+            <Flex style={{ position: 'absolute', inset: 0, zIndex: 10 }} align="center" justify="center">
+              <Text c="dimmed" fs="italic" size="sm">
+                {store.totalFiltersAppliedCount > 0
+                  ? 'No data available for this chart after filtering'
+                  : 'No data available for this chart'}
+              </Text>
+            </Flex>
+          )}
           <Flex direction="row" h={height}>
             {/* Fixed Y Axis */}
             <ScatterYAxis

--- a/frontend/src/Components/Views/HospitalView/HospitalView.tsx
+++ b/frontend/src/Components/Views/HospitalView/HospitalView.tsx
@@ -384,7 +384,7 @@ export function HospitalView() {
                   </Flex>
                   <Box style={{ flex: 1, minHeight: 0, padding: '0 15px' }}>
                     <LoadingOverlay visible={rawChartData === undefined} overlayProps={{ radius: 'sm', blur: 2 }} />
-                    {rawChartData !== undefined && chartData.length === 0 && (
+                    {rawChartData !== undefined && chartData.length === 0 ? (
                       <Flex h="100%" align="center" justify="center">
                         <Text c="dimmed" fs="italic" size="sm">
                           {store.totalFiltersAppliedCount > 0
@@ -392,8 +392,7 @@ export function HospitalView() {
                             : 'No data available for this chart'}
                         </Text>
                       </Flex>
-                    )}
-                    {chartType === 'bar' ? (
+                    ) : chartType === 'bar' ? (
                       // Bar Chart
                       <BarChart
                         h="100%"

--- a/frontend/src/Components/Views/HospitalView/HospitalView.tsx
+++ b/frontend/src/Components/Views/HospitalView/HospitalView.tsx
@@ -8,7 +8,7 @@ import { useObserver } from 'mobx-react-lite';
 import { useDisclosure } from '@mantine/hooks';
 import {
   useMantineTheme, Title, Stack, Card, Flex, Select, Button, CloseButton, ActionIcon, Menu, Modal, Divider, Tooltip,
-  LoadingOverlay,
+  LoadingOverlay, Text,
   Box,
 } from '@mantine/core';
 import { BarChart, LineChart } from '@mantine/charts';
@@ -239,8 +239,8 @@ export function HospitalView() {
           }) => {
             const selectedSet = new Set(store.selectedTimePeriods);
 
-            const rawChartData = store.dashboardChartData[`${aggregation}_${yAxisVar}_${xAxisVar}`] || [];
-            const chartData = rawChartData.map((d) => {
+            const rawChartData = store.dashboardChartData[`${aggregation}_${yAxisVar}_${xAxisVar}`];
+            const chartData = (rawChartData || []).map((d) => {
               if (typeof d.data === 'object') {
                 return { timePeriod: d.timePeriod, ...d.data };
               }
@@ -383,7 +383,16 @@ export function HospitalView() {
                     </Flex>
                   </Flex>
                   <Box style={{ flex: 1, minHeight: 0, padding: '0 15px' }}>
-                    <LoadingOverlay visible={chartData.length === 0} overlayProps={{ radius: 'sm', blur: 2 }} />
+                    <LoadingOverlay visible={rawChartData === undefined} overlayProps={{ radius: 'sm', blur: 2 }} />
+                    {rawChartData !== undefined && chartData.length === 0 && (
+                      <Flex h="100%" align="center" justify="center">
+                        <Text c="dimmed" fs="italic" size="sm">
+                          {store.totalFiltersAppliedCount > 0
+                            ? 'No data available for this chart after filtering'
+                            : 'No data available for this chart'}
+                        </Text>
+                      </Flex>
+                    )}
                     {chartType === 'bar' ? (
                       // Bar Chart
                       <BarChart

--- a/frontend/src/Shell/Shell.tsx
+++ b/frontend/src/Shell/Shell.tsx
@@ -11,7 +11,6 @@ import {
   Anchor,
 } from '@mantine/core';
 import {
-  IconDatabase, IconBook,
   IconArrowNarrowLeftDashed,
   IconArrowNarrowRightDashed, IconDeviceFloppy,
   IconCamera, IconLogout, IconMenu,
@@ -122,18 +121,6 @@ export const Shell = observer(() => {
         </Badge>,
 
       ],
-    },
-    {
-      icon: IconDatabase,
-      label: 'Database',
-      content: <Text>Database content</Text>,
-      disabled: true,
-    },
-    {
-      icon: IconBook,
-      label: 'Learn',
-      content: <Text>Learning content</Text>,
-      disabled: true,
     },
   ];
 
@@ -282,13 +269,6 @@ export const Shell = observer(() => {
                   onClick={() => { setAboutModalOpened(true); }}
                 >
                   About Intelvia
-                </Menu.Item>
-                <Menu.Item
-                  leftSection={<IconBook size={14} />}
-                  onClick={() => { window.open('https://docs.intelvia.app/', '_blank'); }}
-                  disabled
-                >
-                  Documentation
                 </Menu.Item>
                 <Menu.Item
                   leftSection={<IconAt size={14} />}


### PR DESCRIPTION
### Does this PR close any open issues?
N/A

### Give a longer description of what this PR addresses and why it's needed

If filters are so extreme that they result in no data in charts:
- 'No data available for this chart after filtering' (If filters applied)
- 'No data available for this chart' (Else)

### Provide pictures/videos of the behavior before and after these changes (optional)

<img width="2185" height="672" alt="Screenshot 2026-05-11 at 3 09 51 PM" src="https://github.com/user-attachments/assets/edc38bda-6273-4047-8cfa-6177b5c7f59e" />

