### PR TITLE
Hide aggregation toggle for certain metrics in hospital dashboard

### DIFF
--- a/frontend/src/Components/Views/HospitalView/HospitalView.tsx
+++ b/frontend/src/Components/Views/HospitalView/HospitalView.tsx
@@ -35,6 +35,7 @@ import {
   DashboardStatConfig,
   chartColors,
   BLOOD_PRODUCT_COLOR_THEME,
+  DASHBOARD_NO_AGGREGATION_TOGGLE_VARS,
 } from '../../../Types/application';
 import { formatValueForDisplay } from '../../../Utils/dashboard';
 import { getDepartmentContextLabel } from '../../../Utils/departmentContext';
@@ -171,14 +172,16 @@ export function HospitalView() {
           centered
         >
           <Stack gap="md">
-            {/** Modal - choose aggregation for chart or stat */}
-            <Select
-              label="Aggregation"
-              placeholder="Choose aggregation type"
-              data={aggregationOptions}
-              value={selectedAggregation}
-              onChange={(value) => setSelectedAggregation(value || 'Average')}
-            />
+            {/** Modal - choose aggregation for chart or stat (hidden for CMI-weighted metrics) */}
+            {!DASHBOARD_NO_AGGREGATION_TOGGLE_VARS.has(selectedYAxisVar) && (
+              <Select
+                label="Aggregation"
+                placeholder="Choose aggregation type"
+                data={aggregationOptions}
+                value={selectedAggregation}
+                onChange={(value) => setSelectedAggregation(value || 'Average')}
+              />
+            )}
             {/** Modal - choose y-axis for chart or stat */}
             <Select
               label={`${itemModalType === 'chart' ? 'Metric (Y-Axis)' : 'Metric'}`}
@@ -332,17 +335,19 @@ export function HospitalView() {
                         </ActionIcon>
                       </Tooltip>
 
-                      {/* Chart y-axis aggregation toggle */}
-                      <Tooltip label={`Change Y-Axis Aggregation to ${aggregation === 'sum' ? 'Average' : 'Sum'}`}>
-                        <ActionIcon
-                          variant="subtle"
-                          onClick={() => store.setDashboardChartConfig(chartId, {
-                            chartId, yAxisVar, xAxisVar, aggregation: aggregation === 'sum' ? 'avg' : 'sum', chartType,
-                          })}
-                        >
-                          <IconPercentage size={18} color={theme.colors.gray[6]} stroke={3} />
-                        </ActionIcon>
-                      </Tooltip>
+                      {/* Chart y-axis aggregation toggle (hidden for CMI-weighted metrics) */}
+                      {!DASHBOARD_NO_AGGREGATION_TOGGLE_VARS.has(yAxisVar) && (
+                        <Tooltip label={`Change Y-Axis Aggregation to ${aggregation === 'sum' ? 'Average' : 'Sum'}`}>
+                          <ActionIcon
+                            variant="subtle"
+                            onClick={() => store.setDashboardChartConfig(chartId, {
+                              chartId, yAxisVar, xAxisVar, aggregation: aggregation === 'sum' ? 'avg' : 'sum', chartType,
+                            })}
+                          >
+                            <IconPercentage size={18} color={theme.colors.gray[6]} stroke={3} />
+                          </ActionIcon>
+                        </Tooltip>
+                      )}
                       {/** Chart x-axis aggregation toggle */}
                       <Tooltip label={`Change X-Axis to ${xAxisVar === 'month' ? 'Quarter' : xAxisVar === 'quarter' ? 'Year' : 'Month'}`}>
                         <ActionIcon

--- a/frontend/src/Components/Views/HospitalView/HospitalView.tsx
+++ b/frontend/src/Components/Views/HospitalView/HospitalView.tsx
@@ -172,16 +172,15 @@ export function HospitalView() {
           centered
         >
           <Stack gap="md">
-            {/** Modal - choose aggregation for chart or stat (hidden for CMI-weighted metrics) */}
-            {!DASHBOARD_NO_AGGREGATION_TOGGLE_VARS.has(selectedYAxisVar) && (
-              <Select
-                label="Aggregation"
-                placeholder="Choose aggregation type"
-                data={aggregationOptions}
-                value={selectedAggregation}
-                onChange={(value) => setSelectedAggregation(value || 'Average')}
-              />
-            )}
+            {/** Modal - choose aggregation for chart or stat (disabled for CMI-weighted metrics) */}
+            <Select
+              label="Aggregation"
+              placeholder="Choose aggregation type"
+              data={aggregationOptions}
+              value={selectedAggregation}
+              onChange={(value) => setSelectedAggregation(value || 'Average')}
+              disabled={DASHBOARD_NO_AGGREGATION_TOGGLE_VARS.has(selectedYAxisVar)}
+            />
             {/** Modal - choose y-axis for chart or stat */}
             <Select
               label={`${itemModalType === 'chart' ? 'Metric (Y-Axis)' : 'Metric'}`}
@@ -335,19 +334,18 @@ export function HospitalView() {
                         </ActionIcon>
                       </Tooltip>
 
-                      {/* Chart y-axis aggregation toggle (hidden for CMI-weighted metrics) */}
-                      {!DASHBOARD_NO_AGGREGATION_TOGGLE_VARS.has(yAxisVar) && (
-                        <Tooltip label={`Change Y-Axis Aggregation to ${aggregation === 'sum' ? 'Average' : 'Sum'}`}>
-                          <ActionIcon
-                            variant="subtle"
-                            onClick={() => store.setDashboardChartConfig(chartId, {
-                              chartId, yAxisVar, xAxisVar, aggregation: aggregation === 'sum' ? 'avg' : 'sum', chartType,
-                            })}
-                          >
-                            <IconPercentage size={18} color={theme.colors.gray[6]} stroke={3} />
-                          </ActionIcon>
-                        </Tooltip>
-                      )}
+                      {/* Chart y-axis aggregation toggle (disabled for CMI-weighted metrics) */}
+                      <Tooltip label={`Change Y-Axis Aggregation to ${aggregation === 'sum' ? 'Average' : 'Sum'}`}>
+                        <ActionIcon
+                          variant="subtle"
+                          disabled={DASHBOARD_NO_AGGREGATION_TOGGLE_VARS.has(yAxisVar)}
+                          onClick={() => store.setDashboardChartConfig(chartId, {
+                            chartId, yAxisVar, xAxisVar, aggregation: aggregation === 'sum' ? 'avg' : 'sum', chartType,
+                          })}
+                        >
+                          <IconPercentage size={18} color={theme.colors.gray[6]} stroke={3} />
+                        </ActionIcon>
+                      </Tooltip>
                       {/** Chart x-axis aggregation toggle */}
                       <Tooltip label={`Change X-Axis to ${xAxisVar === 'month' ? 'Quarter' : xAxisVar === 'quarter' ? 'Year' : 'Month'}`}>
                         <ActionIcon

--- a/frontend/src/Types/application.ts
+++ b/frontend/src/Types/application.ts
@@ -644,6 +644,13 @@ export const BLOOD_PRODUCT_TRANSFUSIONS_PER_CMI_VISIT_OPTIONS = [
   },
 ] as const;
 
+// Metrics that have no meaningful sum/avg distinction (e.g. CMI-weighted rates)
+export const DASHBOARD_NO_AGGREGATION_TOGGLE_VARS = new Set<string>([
+  CASE_MIX_INDEX.value,
+  TRANSFUSIONS_PER_CMI_VISIT.value,
+  ...BLOOD_PRODUCT_TRANSFUSIONS_PER_CMI_VISIT_OPTIONS.map((o) => o.value),
+]);
+
 // Costs -----------------------------------------------------------
 export const DEFAULT_UNIT_COSTS: Record<Cost, number> = {
   rbc_units_cost: 200,

--- a/frontend/src/Types/application.ts
+++ b/frontend/src/Types/application.ts
@@ -645,7 +645,9 @@ export const BLOOD_PRODUCT_TRANSFUSIONS_PER_CMI_VISIT_OPTIONS = [
 ] as const;
 
 // Metrics that have no meaningful sum/avg distinction (e.g. CMI-weighted rates)
-export const DASHBOARD_NO_AGGREGATION_TOGGLE_VARS = new Set<string>([
+export const DASHBOARD_NO_AGGREGATION_TOGGLE_VARS = new Set<
+  typeof dashboardYAxisVars[number]
+>([
   CASE_MIX_INDEX.value,
   TRANSFUSIONS_PER_CMI_VISIT.value,
   ...BLOOD_PRODUCT_TRANSFUSIONS_PER_CMI_VISIT_OPTIONS.map((o) => o.value),


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #587 

### Give a longer description of what this PR addresses and why it's needed

Don't show the aggregation toggle for metrics that don't need it:
- Case mix index
- Any metric with "/ CMI weighted discharge"

### Provide pictures/videos of the behavior before and after these changes (optional)

<img width="801" height="313" alt="Screenshot 2026-05-15 at 11 13 10 AM" src="https://github.com/user-attachments/assets/f9eda5de-275e-450b-b902-2ff7110a92cb" />
