### PR TITLE
Add 'provider' to dumbbell and scatterplot options

### DIFF
--- a/frontend/src/Components/Views/DepartmentView/Charts/DumbbellChart.tsx
+++ b/frontend/src/Components/Views/DepartmentView/Charts/DumbbellChart.tsx
@@ -19,6 +19,7 @@ import {
   LAB_RESULTS, DUMBBELL_X_AXIS_OPTIONS, DUMBBELL_MARGIN,
   DUMBBELL_CHAR_WIDTH_CASE, DUMBBELL_DOT_RADIUS,
   DUMBBELL_DRAG_LIMIT, DumbbellLabConfig as LabConfig,
+  isProviderXAxis,
 } from '../../../../Types/application';
 import { smallHoverColor } from '../../../../Theme/mantineTheme';
 import { getProcessedDumbbellData, calculateDumbbellLayout } from './DumbbellUtils';
@@ -967,7 +968,7 @@ export const DumbbellChartContent = memo(({
             >
               <title>
                 {(() => {
-                  if (selectedX === 'surgeon' || selectedX === 'anesthesiologist' || selectedX === 'provider') return `Surgical Cases for ${binGroup.label}`;
+                  if (isProviderXAxis(selectedX)) return `Surgical Cases for ${binGroup.label}`;
                   if (selectedX === 'year' || selectedX === 'quarter') return `Surgical Cases in ${binGroup.label}`;
                   if (['rbc', 'platelet', 'cryo', 'ffp'].includes(selectedX)) {
                     return `Surgical Cases where ${binGroup.label} Transfused`;
@@ -1599,7 +1600,7 @@ export function DumbbellChart({ chartConfig }: { chartConfig: DumbbellChartConfi
             />
 
             {/* Provider Sort Toggle */}
-            {(selectedX === 'surgeon' || selectedX === 'anesthesiologist' || selectedX === 'provider') && (
+            {(isProviderXAxis(selectedX)) && (
               <Box style={{
                 position: 'absolute', bottom: 0, right: 5, zIndex: 10,
               }}

--- a/frontend/src/Components/Views/DepartmentView/Charts/DumbbellChart.tsx
+++ b/frontend/src/Components/Views/DepartmentView/Charts/DumbbellChart.tsx
@@ -967,8 +967,7 @@ export const DumbbellChartContent = memo(({
             >
               <title>
                 {(() => {
-                  if (selectedX === 'surgeon') return `Surgical Cases for ${binGroup.label}`;
-                  if (selectedX === 'anesthesiologist') return `Surgical Cases for ${binGroup.label}`;
+                  if (selectedX === 'surgeon' || selectedX === 'anesthesiologist' || selectedX === 'provider') return `Surgical Cases for ${binGroup.label}`;
                   if (selectedX === 'year' || selectedX === 'quarter') return `Surgical Cases in ${binGroup.label}`;
                   if (['rbc', 'platelet', 'cryo', 'ffp'].includes(selectedX)) {
                     return `Surgical Cases where ${binGroup.label} Transfused`;
@@ -1600,7 +1599,7 @@ export function DumbbellChart({ chartConfig }: { chartConfig: DumbbellChartConfi
             />
 
             {/* Provider Sort Toggle */}
-            {(selectedX === 'surgeon' || selectedX === 'anesthesiologist') && (
+            {(selectedX === 'surgeon' || selectedX === 'anesthesiologist' || selectedX === 'provider') && (
               <Box style={{
                 position: 'absolute', bottom: 0, right: 5, zIndex: 10,
               }}

--- a/frontend/src/Components/Views/DepartmentView/Charts/DumbbellUtils.ts
+++ b/frontend/src/Components/Views/DepartmentView/Charts/DumbbellUtils.ts
@@ -25,6 +25,14 @@ export function getProcessedDumbbellData(
 
   // Grouping Logic based on selectedX
   filteredData.forEach((d: DumbbellCase) => {
+    if (selectedX === 'provider') {
+      [d.surgeon_prov_name, d.anesth_prov_name].forEach((k) => {
+        if (!k) return;
+        if (!groupedByBinGroup.has(k)) groupedByBinGroup.set(k, []);
+        groupedByBinGroup.get(k)?.push(d);
+      });
+      return;
+    }
     let key = d.surgeon_prov_name; // Default Surgeon Name
     if (selectedX === 'anesthesiologist') key = d.anesth_prov_name;
     else if (selectedX === 'year') {

--- a/frontend/src/Components/Views/DepartmentView/Charts/DumbbellUtils.ts
+++ b/frontend/src/Components/Views/DepartmentView/Charts/DumbbellUtils.ts
@@ -1,6 +1,6 @@
 import {
   DumbbellCase, DumbbellData, DumbbellLabConfig, DumbbellSortState,
-  DUMBBELL_CHAR_WIDTH_CASE,
+  DUMBBELL_CHAR_WIDTH_CASE, isProviderXAxis,
 } from '../../../../Types/application';
 
 // Grouping and processing logic
@@ -261,7 +261,7 @@ export function calculateDumbbellLayout(
 
     let binGroupWidth = currentX - binGroupStartX;
     let isOverflowing = false;
-    const isSurgeon = selectedX === 'surgeon' || selectedX === 'anesthesiologist';
+    const isSurgeon = isProviderXAxis(selectedX);
 
     if (isSurgeon) {
       const MIN_SURGEON_WIDTH = 40;

--- a/frontend/src/Components/Views/DepartmentView/Charts/ScatterPlotUtils.ts
+++ b/frontend/src/Components/Views/DepartmentView/Charts/ScatterPlotUtils.ts
@@ -1,6 +1,7 @@
 import {
   DumbbellCase,
   SCATTER_CHAR_WIDTH_CASE,
+  isProviderXAxis,
 } from '../../../../Types/application';
 
 // ---------- Types ----------
@@ -226,7 +227,7 @@ export function calculateScatterLayout(
     const binGroupWidth = currentX - binGroupStartX;
     let isOverflowing = false;
 
-    const isProvider = selectedX === 'surgeon' || selectedX === 'anesthesiologist';
+    const isProvider = isProviderXAxis(selectedX);
 
     // Ensure bin group labels fit
     const fullWidth = measureText(displayLabel);

--- a/frontend/src/Components/Views/DepartmentView/Charts/ScatterPlotUtils.ts
+++ b/frontend/src/Components/Views/DepartmentView/Charts/ScatterPlotUtils.ts
@@ -105,6 +105,13 @@ export function getProcessedScatterData(
   const groupedByBinGroup = new Map<string, DumbbellCase[]>();
 
   filteredData.forEach((d: DumbbellCase) => {
+    if (selectedX === 'provider') {
+      [d.surgeon_prov_name || 'Unknown', d.anesth_prov_name || 'Unknown'].forEach((k) => {
+        if (!groupedByBinGroup.has(k)) groupedByBinGroup.set(k, []);
+        groupedByBinGroup.get(k)?.push(d);
+      });
+      return;
+    }
     let key = '';
     if (selectedX === 'surgeon') {
       key = d.surgeon_prov_name || 'Unknown';

--- a/frontend/src/Types/application.ts
+++ b/frontend/src/Types/application.ts
@@ -861,6 +861,7 @@ export type CostBarData = CostBarDatum[];
 
 // --- Dumbbell Chart ---
 export const DUMBBELL_X_AXIS_OPTIONS = [
+  { value: 'provider', label: 'Provider' },
   { value: 'surgeon', label: 'Surgeon' },
   { value: 'anesthesiologist', label: 'Anesthesiologist' },
   { value: 'year', label: 'Year' },
@@ -946,6 +947,7 @@ export type DumbbellData = DumbbellCase[];
 
 // --- Scatter plots ---
 export const SCATTER_X_AXIS_OPTIONS = [
+  { value: 'provider' as const, label: 'Provider', isDiscrete: true },
   { value: 'surgeon' as const, label: 'Surgeon', isDiscrete: true },
   { value: 'anesthesiologist' as const, label: 'Anesthesiologist', isDiscrete: true },
   { value: 'year' as const, label: 'Year', isDiscrete: true },

--- a/frontend/src/Types/application.ts
+++ b/frontend/src/Types/application.ts
@@ -874,6 +874,9 @@ export const DUMBBELL_X_AXIS_OPTIONS = [
 ] as const;
 export type DumbbellXAxisVar = typeof DUMBBELL_X_AXIS_OPTIONS[number]['value'];
 
+export const PROVIDER_X_AXIS_VALUES = ['surgeon', 'anesthesiologist', 'provider'] as const;
+export const isProviderXAxis = (v: string) => PROVIDER_X_AXIS_VALUES.includes(v as typeof PROVIDER_X_AXIS_VALUES[number]);
+
 export const DUMBBELL_Y_AXIS_OPTIONS = [
   { value: 'hgb', label: 'Hemoglobin' },
   { value: 'platelet', label: 'Platelet Count' },


### PR DESCRIPTION
### Does this PR close any open issues?
N/A

### Give a longer description of what this PR addresses and why it's needed
**Before:** In dumbbell chart and scatter plot, there was only options 'surgeon' and 'anesthesiologist', not an option for both called provider.
**After:** Add an option for 'provider' for those two charts. That's all


### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="1101" height="380" alt="Screenshot 2026-05-15 at 11 54 47 AM" src="https://github.com/user-attachments/assets/f07c1ee6-05b3-4eba-9dd1-273f70c82fbb" />
