### PR TITLE
Implement faster loading of department view

### DIFF
--- a/frontend/src/Shell/Shell.tsx
+++ b/frontend/src/Shell/Shell.tsx
@@ -30,6 +30,7 @@ import {
 } from '@tabler/icons-react';
 import { Store } from '../Store/Store';
 import { useThemeConstants } from '../Theme/mantineTheme';
+import { ActiveTab } from '../Types/application';
 import classes from './Shell.module.css';
 import { HospitalView } from '../Components/Views/HospitalView/HospitalView';
 import { DepartmentView } from '../Components/Views/DepartmentView/DepartmentView';
@@ -74,7 +75,7 @@ export const Shell = observer(() => {
   const defaultTab = TABS[0].key;
 
   // Active tab in the view tabs
-  const setActiveTab = (tab: string) => {
+  const setActiveTab = (tab: ActiveTab) => {
     store.actions.setUiState({ activeTab: tab });
   };
 
@@ -183,7 +184,7 @@ export const Shell = observer(() => {
               variant="outline"
               value={store.state.ui.activeTab}
               onChange={(value) => {
-                if (value) setActiveTab(value);
+                if (value) setActiveTab(value as ActiveTab);
               }}
               radius="md"
               defaultValue={defaultTab}

--- a/frontend/src/Store/Store.spec.ts
+++ b/frontend/src/Store/Store.spec.ts
@@ -437,8 +437,8 @@ describe('Store - RootStore', () => {
     });
 
     test('should set UI state', () => {
-      store.actions.setUiState({ activeTab: 'Providers' });
-      expect(store.uiState.activeTab).toBe('Providers');
+      store.actions.setUiState({ activeTab: 'Provider' });
+      expect(store.uiState.activeTab).toBe('Provider');
     });
 
     test('should toggle private mode', () => {

--- a/frontend/src/Store/Store.ts
+++ b/frontend/src/Store/Store.ts
@@ -34,6 +34,7 @@ import {
   dashboardYAxisOptions,
   providerViewYAxisOptions,
   DEFAULT_UNIT_COSTS,
+  ActiveTab,
 } from '../Types/application';
 import { compareTimePeriods, safeParseDate } from '../Utils/dates';
 import { formatValueForDisplay } from '../Utils/dashboard';
@@ -970,7 +971,7 @@ export interface ApplicationState {
     clampPercentile: number;
   };
   ui: {
-    activeTab: string;
+    activeTab: ActiveTab;
     departmentViewDepartment: string | null;
     leftToolbarOpened: boolean;
     activeLeftPanel: number | null;
@@ -2883,7 +2884,10 @@ export class RootStore {
         'SELECT attending_provider_department FROM visits GROUP BY attending_provider_department ORDER BY COUNT(DISTINCT visit_no) DESC LIMIT 1',
       );
       const dept = (result.toArray()[0]?.attending_provider_department as string) ?? null;
-      if (dept) { this.actions.setUiState({ departmentViewDepartment: dept }); return; }
+      if (dept) {
+        this.actions.setUiState({ departmentViewDepartment: dept });
+        return;
+      }
     }
 
     const dateFrom = filterValues.dateFrom.toISOString();

--- a/frontend/src/Store/Store.ts
+++ b/frontend/src/Store/Store.ts
@@ -2422,6 +2422,7 @@ export class RootStore {
     const newStats = this.departmentStatConfigs.filter((s) => s.statId !== statId);
     this.actions.updateDepartmentState({ statConfigs: newStats }, 'Remove Department Stat');
   }
+
   // endregion
 
   // region Filters
@@ -2874,6 +2875,17 @@ export class RootStore {
     if (!this.duckDB) return;
     const { filterValues } = this;
     if (!filterValues.dateFrom || !filterValues.dateTo) return;
+
+    // If the Department tab is active but no department is selected yet, resolve
+    // the default (largest) department first and let the reaction re-run with it set.
+    if (this.uiState.activeTab === 'Department' && !this.uiState.departmentViewDepartment) {
+      const result = await this.duckDB.query(
+        'SELECT attending_provider_department FROM visits GROUP BY attending_provider_department ORDER BY COUNT(DISTINCT visit_no) DESC LIMIT 1',
+      );
+      const dept = (result.toArray()[0]?.attending_provider_department as string) ?? null;
+      if (dept) { this.actions.setUiState({ departmentViewDepartment: dept }); return; }
+    }
+
     const dateFrom = filterValues.dateFrom.toISOString();
     const dateTo = filterValues.dateTo.toISOString();
 
@@ -2952,21 +2964,27 @@ export class RootStore {
 
     // Update all the data retrievers
     await this.updateFilteredVisitsLength();
-    await this.computeDashboardChartData();
-    await this.computeDashboardStatData();
-    await this.computeDepartmentChartData();
-    await this.computeDepartmentStatData();
+    if (activeTab === 'Hospital') {
+      await this.computeDashboardChartData();
+      await this.computeDashboardStatData();
+    }
+    if (activeTab === 'Department') {
+      await this.computeDepartmentChartData();
+      await this.computeDepartmentStatData();
+    }
     await this.generateHistogramData();
     await this.updateSelectedVisits();
 
-    // Update provider store
-    const { dateStart, dateEnd } = this.providersStore;
-    await this.providersStore.fetchProviderList(dateStart, dateEnd);
-    await this.providersStore.getProviderCharts(dateStart, dateEnd);
-    if (this.providersStore.selectedProvider) {
-      await this.providersStore.fetchSelectedProvSurgCount(dateStart, dateEnd);
-      await this.providersStore.fetchSelectedProvRbcUnits(dateStart, dateEnd);
-      await this.providersStore.fetchCmiComparison(dateStart, dateEnd);
+    // Update provider store only when on Provider tab
+    if (activeTab === 'Provider') {
+      const { dateStart, dateEnd } = this.providersStore;
+      await this.providersStore.fetchProviderList(dateStart, dateEnd);
+      await this.providersStore.getProviderCharts(dateStart, dateEnd);
+      if (this.providersStore.selectedProvider) {
+        await this.providersStore.fetchSelectedProvSurgCount(dateStart, dateEnd);
+        await this.providersStore.fetchSelectedProvRbcUnits(dateStart, dateEnd);
+        await this.providersStore.fetchCmiComparison(dateStart, dateEnd);
+      }
     }
   }
 

--- a/frontend/src/Types/application.ts
+++ b/frontend/src/Types/application.ts
@@ -2,6 +2,8 @@ import { BLOOD_COMPONENTS } from './bloodProducts';
 
 // Time formatting ------------------------------------------------
 // Time period types
+export type ActiveTab = 'Hospital' | 'Department' | 'Provider' | 'Settings';
+
 export type Quarter = `${number}-Q${1 | 2 | 3 | 4}`;
 export type Month = `${number}-${string}`; // e.g. "2023-Jan"
 export type Year = `${number}`; // e.g. "2023"


### PR DESCRIPTION
### Does this PR close any open issues?
N/A

# Fix Department View Loading Performance

## Summary

This PR makes data loading tab-aware and department-scoped so the app only computes what is visible on screen, preventing several expensive redundant DuckDB passes.

---

## Optimizations

1. Guard Department tab loading until a department is selected
When the active tab is Department and no department is selected, updateFilteredData now:

     1. Runs a one-row query to find the largest department.
     2. Sets departmentViewDepartment.
     3. Returns early so no additional compute passes run with an unscoped Department state.
     4. This prevents an unnecessary initial full compute pass that would be invalidated immediately after auto-select.

2. Compute only data for the active tab
updateFilteredData no longer computes all tab datasets on every filter change.

     1. Hospital tab now computes only dashboard chart/stat data.
     2. Department tab now computes only department chart/stat data.
     3. Provider store fetches/charts now run only on the Provider tab.
Shared updates still run for all tabs where needed:

     1. filtered visit count update
     2. histogram generation
     3. selected visits refresh

3. Add strong typing for activeTab - additional request by @haihan-lin 
Added ActiveTab in application.ts and applied it to UI state and tab setter paths.

     1. Defined ActiveTab as Hospital | Department | Provider | Settings.
     2. Updated Store UI state activeTab type from string to ActiveTab.
     3. Updated Shell tab setter to accept ActiveTab.
     4. Corrected a Store.spec test value from Providers to Provider.