### PR TITLE
Fix state save and load flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ mariadb_data/
 *.zip
 
 __pycache__/
+
+clarity-queries/
+.pytest_cache/
+provider*.csv

--- a/backend/api/tests/test_state.py
+++ b/backend/api/tests/test_state.py
@@ -1,0 +1,111 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from api.models import State, StateAccess
+
+
+class StateEndpointTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.owner = User.objects.create_user(username="alice", password="secret")
+        self.reader = User.objects.create_user(username="bob", password="secret")
+        self.client.force_login(self.owner)
+
+    def test_create_state_returns_created_and_can_be_loaded_by_encoded_name(self):
+        state_name = "Case mix & blood = view?"
+
+        response = self.client.post(
+            "/api/state",
+            {
+                "name": state_name,
+                "definition": "compressed-state",
+                "public": "true",
+            },
+        )
+
+        self.assertEqual(response.status_code, 201)
+
+        response = self.client.get("/api/state", {"name": state_name})
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["name"], state_name)
+        self.assertEqual(payload["definition"], "compressed-state")
+        self.assertTrue(payload["public"])
+
+    def test_update_state_preserves_public_flag_when_omitted(self):
+        State.objects.create(
+            name="Shared State",
+            definition="before",
+            owner=self.owner.username,
+            public=True,
+        )
+
+        response = self.client.put(
+            "/api/state",
+            data=json.dumps(
+                {
+                    "old_name": "Shared State",
+                    "new_name": "Shared State",
+                    "new_definition": "after",
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        state = State.objects.get(name="Shared State")
+        self.assertEqual(state.definition, "after")
+        self.assertTrue(state.public)
+
+    def test_update_state_applies_explicit_public_flag(self):
+        State.objects.create(
+            name="Private State",
+            definition="before",
+            owner=self.owner.username,
+            public=False,
+        )
+
+        response = self.client.put(
+            "/api/state",
+            data=json.dumps(
+                {
+                    "old_name": "Private State",
+                    "new_name": "Private State",
+                    "new_definition": "after",
+                    "new_public": True,
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(State.objects.get(name="Private State").public)
+
+    def test_share_state_returns_created_for_new_share(self):
+        State.objects.create(
+            name="Owner State",
+            definition="compressed-state",
+            owner=self.owner.username,
+            public=False,
+        )
+
+        response = self.client.post(
+            "/api/share_state",
+            {
+                "name": "Owner State",
+                "user": self.reader.username,
+                "role": "RE",
+            },
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(
+            StateAccess.objects.filter(
+                state__name="Owner State",
+                user=self.reader.username,
+                role="RE",
+            ).exists()
+        )

--- a/backend/api/views/state.py
+++ b/backend/api/views/state.py
@@ -1,4 +1,5 @@
 import ast
+import json
 from django.http import (
     HttpResponse,
     JsonResponse,
@@ -13,6 +14,22 @@ from django.views.decorators.http import require_http_methods
 from api.models import State, StateAccess, AccessLevel
 from .decorators.conditional_login_required import conditional_login_required
 from .utils.utils import log_request
+
+
+def parse_request_body(request):
+    body = request.body.decode()
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        return ast.literal_eval(body)
+
+
+def parse_bool(value):
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() == "true"
 
 
 @require_http_methods(["GET", "POST", "PUT", "DELETE"])
@@ -72,19 +89,17 @@ def state(request):
             )
             new_state.save()
 
-            return HttpResponse("state object created", 201)
+            return HttpResponse("state object created", status=201)
         else:
             return HttpResponseBadRequest("missing params: [name, definition, owner]")
 
     elif request.method == "PUT":
         # Get the required information from the request body
-        put = ast.literal_eval(request.body.decode())
+        put = parse_request_body(request)
         old_name = put.get("old_name")
         new_name = put.get("new_name")
         new_definition = put.get("new_definition")
         new_public_request = put.get("new_public")
-
-        new_public = True if new_public_request == "true" else False
 
         owned_states = [o.name for o in State.objects.all().filter(owner=request.user)]
         public_states = [o.name for o in State.objects.all().filter(public=True)]
@@ -110,14 +125,15 @@ def state(request):
         result = State.objects.get(name=old_name)
         result.name = new_name
         result.definition = new_definition
-        result.public = new_public
+        if new_public_request is not None:
+            result.public = parse_bool(new_public_request)
         result.save()
 
         return HttpResponse("state object updated")
 
     elif request.method == "DELETE":
         # Get the required information from the request body
-        delete = ast.literal_eval(request.body.decode())
+        delete = parse_request_body(request)
         name = delete.get("name")
 
         # Delete the matching State object
@@ -190,7 +206,7 @@ def share_state(request):
         user=user,
         role=role,
     )
-    return HttpResponse("Added new user to role", 201)
+    return HttpResponse("Added new user to role", status=201)
 
 
 @require_http_methods(["GET"])

--- a/backend/api/views/utils/utils.py
+++ b/backend/api/views/utils/utils.py
@@ -1,5 +1,6 @@
 import ast
 import csv
+import json
 import logging
 from django.db import connections
 
@@ -41,8 +42,12 @@ def log_request(request, paramsToExclude=[]):
         params = request.GET
     if request.method == "POST":
         params = request.POST
-    if request.method == "PUT" or request.method == "DELTE":
-        params = ast.literal_eval(request.body.decode())
+    if request.method == "PUT" or request.method == "DELETE":
+        body = request.body.decode()
+        try:
+            params = json.loads(body)
+        except json.JSONDecodeError:
+            params = ast.literal_eval(body)
 
     # Remove excluded params
     params = {k: v for k, v in params.items() if k not in paramsToExclude}

--- a/frontend/src/Components/Modals/ManageStateDialog.tsx
+++ b/frontend/src/Components/Modals/ManageStateDialog.tsx
@@ -38,7 +38,7 @@ function ManageStateDialog({ setOpenSaveState, setVisbility, visible }: Props) {
       },
       body: JSON.stringify({ name: stateName }),
     }).then((response) => {
-      if (response.status === 200) {
+      if (response.ok) {
         if (store.configStore.loadedStateName === stateName) {
           store.configStore.loadedStateName = '';
         }
@@ -47,8 +47,8 @@ function ManageStateDialog({ setOpenSaveState, setVisbility, visible }: Props) {
         store.configStore.snackBarMessage = 'Deletion succeed.';
         store.configStore.openSnackBar = true;
       } else {
-        response.text().then(() => {
-          store.configStore.snackBarMessage = `An error occurred: ${response.statusText}`;
+        response.text().then((message) => {
+          store.configStore.snackBarMessage = `An error occurred: ${message || response.statusText}`;
           store.configStore.snackBarIsError = true;
           store.configStore.openSnackBar = true;
           console.error('There has been a problem with your fetch operation:', response.statusText);

--- a/frontend/src/Components/Modals/SaveStateModal.tsx
+++ b/frontend/src/Components/Modals/SaveStateModal.tsx
@@ -22,8 +22,6 @@ function SaveStateModal({ visible, setVisibility }: Props) {
     setStateName(store.configStore.stateToUpdate);
   }, [store.configStore.stateToUpdate]);
 
-  const capitalizeFirstLetter = (string: string) => string.charAt(0).toUpperCase() + string.slice(1);
-
   const onSuccess = () => {
     setVisibility(false);
     store.configStore.snackBarIsError = false;
@@ -40,6 +38,19 @@ function SaveStateModal({ visible, setVisibility }: Props) {
     console.error('There has been a problem with your fetch operation:', errorMessage);
   };
 
+  const getErrorMessage = async (response: Response) => {
+    const message = await response.text();
+    return message || response.statusText;
+  };
+
+  const updateSavedStateName = (oldName: string, newName: string) => {
+    const savedStates = store.configStore.savedState.filter((name) => name !== oldName);
+    if (!savedStates.includes(newName)) {
+      savedStates.push(newName);
+    }
+    store.configStore.setSavedState(savedStates);
+  };
+
   const saveNewState = async () => {
     const csrftoken = await simulateAPIClick();
     if (store.configStore.stateToUpdate) {
@@ -53,17 +64,16 @@ function SaveStateModal({ visible, setVisibility }: Props) {
           'Access-Control-Allow-Credentials': 'true',
         },
         body: JSON.stringify({
-          old_name: store.configStore.stateToUpdate, new_name: stateName, new_definition: store.provenance.exportState(false), new_public: capitalizeFirstLetter(publicAccess.toString()),
+          old_name: store.configStore.stateToUpdate, new_name: stateName, new_definition: store.provenance.exportState(false), new_public: publicAccess.toString(),
         }),
       }).then((response) => {
-        if (response.status === 200) {
+        if (response.ok) {
+          updateSavedStateName(store.configStore.stateToUpdate, stateName);
           store.configStore.stateToUpdate = '';
           store.configStore.loadedStateName = stateName;
           onSuccess();
         } else {
-          response.text().then(() => {
-            onFail(response.statusText);
-          });
+          getErrorMessage(response).then(onFail);
         }
       }).catch((error) => {
         onFail(error.toString());
@@ -81,15 +91,21 @@ function SaveStateModal({ visible, setVisibility }: Props) {
           'Content-Type': 'application/x-www-form-urlencoded',
           'X-CSRFToken': csrftoken || '',
         },
-        body: `csrfmiddlewaretoken=${csrftoken}&name=${stateName}&definition=${store.provenance.exportState(false)}&public=${publicAccess.toString()}`,
+        body: new URLSearchParams({
+          csrfmiddlewaretoken: csrftoken || '',
+          name: stateName,
+          definition: store.provenance.exportState(false),
+          public: publicAccess.toString(),
+        }),
       }).then((response) => {
-        if (response.status === 200) {
+        if (response.ok) {
           store.configStore.loadedStateName = stateName;
+          if (!store.configStore.savedState.includes(stateName)) {
+            store.configStore.addNewState(stateName);
+          }
           onSuccess();
         } else {
-          response.text().then(() => {
-            onFail(response.statusText);
-          });
+          getErrorMessage(response).then(onFail);
         }
       }).catch((error) => {
         onFail(error.toString());

--- a/frontend/src/Components/Modals/StateAccessControl.tsx
+++ b/frontend/src/Components/Modals/StateAccessControl.tsx
@@ -27,7 +27,8 @@ function StateAccessControl({ stateName, openStateAccessControl, setOpenStateAcc
 
   const makeStateAccessRequest = () => {
     if (stateName) {
-      fetch(`${import.meta.env.VITE_QUERY_URL}state_unids?state_name=${stateName}`)
+      const params = new URLSearchParams({ state_name: stateName });
+      fetch(`${import.meta.env.VITE_QUERY_URL}state_unids?${params}`)
         .then((response) => response.json())
         .then((data) => {
           //   const result = data.result;
@@ -62,10 +63,15 @@ function StateAccessControl({ stateName, openStateAccessControl, setOpenStateAcc
         'X-CSRFToken': csrftoken || '',
         'Access-Control-Allow-Credentials': 'true',
       },
-      body: `csrfmiddlewaretoken=${csrftoken}&name=${stateName}&user=${uID}&role=${newAccess}`,
+      body: new URLSearchParams({
+        csrfmiddlewaretoken: csrftoken || '',
+        name: stateName,
+        user: uID,
+        role: newAccess,
+      }),
     })
       .then((response) => {
-        if (response.status === 200) {
+        if (response.ok) {
           store.configStore.snackBarIsError = false;
           store.configStore.snackBarMessage = 'Change succeed.';
           store.configStore.openSnackBar = true;
@@ -74,9 +80,9 @@ function StateAccessControl({ stateName, openStateAccessControl, setOpenStateAcc
           // updateAccessArray(newAccessArray)
           makeStateAccessRequest();
         } else {
-          response.text().then(() => {
+          response.text().then((message) => {
             store.configStore.snackBarIsError = true;
-            store.configStore.snackBarMessage = `An error occurred: ${response.statusText}`;
+            store.configStore.snackBarMessage = `An error occurred: ${message || response.statusText}`;
             store.configStore.openSnackBar = true;
 
             console.error('There has been a problem with your fetch operation:', response.statusText);

--- a/frontend/src/Components/Modals/UIDInputModal.tsx
+++ b/frontend/src/Components/Modals/UIDInputModal.tsx
@@ -27,10 +27,15 @@ function UIDInputModal({ stateName, visible, setVisibility }: Props) {
         'X-CSRFToken': csrftoken || '',
         'Access-Control-Allow-Credentials': 'true',
       },
-      body: `csrfmiddlewaretoken=${csrftoken}&name=${stateName}&user=${`u${uIDInput}`}&role=${writeAccess ? 'WR' : 'RE'}`,
+      body: new URLSearchParams({
+        csrfmiddlewaretoken: csrftoken || '',
+        name: stateName,
+        user: `u${uIDInput}`,
+        role: writeAccess ? 'WR' : 'RE',
+      }),
     })
       .then((response) => {
-        if (response.status === 200) {
+        if (response.ok) {
           store.configStore.snackBarIsError = false;
           store.configStore.snackBarMessage = 'State shared successfully!';
           store.configStore.openSnackBar = true;
@@ -39,9 +44,9 @@ function UIDInputModal({ stateName, visible, setVisibility }: Props) {
           setWriteAccess(false);
           setVisibility(false);
         } else {
-          response.text().then(() => {
+          response.text().then((message) => {
             store.configStore.snackBarIsError = true;
-            store.configStore.snackBarMessage = `An error occurred: ${response.statusText}`;
+            store.configStore.snackBarMessage = `An error occurred: ${message || response.statusText}`;
             store.configStore.openSnackBar = true;
             console.error('There has been a problem with your fetch operation:', response.statusText);
           });

--- a/frontend/src/Components/Utilities/TopMenu/RegularModeMenu.tsx
+++ b/frontend/src/Components/Utilities/TopMenu/RegularModeMenu.tsx
@@ -83,14 +83,14 @@ function RegularModeMenu() {
       },
       body: JSON.stringify({ old_name: store.configStore.loadedStateName, new_name: store.configStore.loadedStateName, new_definition: store.provenance.exportState(false) }),
     }).then((response) => {
-      if (response.status === 200) {
+      if (response.ok) {
         store.configStore.snackBarIsError = false;
         store.configStore.snackBarMessage = 'State updated!';
         store.configStore.openSnackBar = true;
       } else {
-        response.text().then(() => {
+        response.text().then((message) => {
           store.configStore.snackBarIsError = true;
-          store.configStore.snackBarMessage = `An error occurred: ${response.statusText}`;
+          store.configStore.snackBarMessage = `An error occurred: ${message || response.statusText}`;
           store.configStore.openSnackBar = true;
         });
       }

--- a/frontend/src/Components/Utilities/TopMenu/StateManagementSuite.tsx
+++ b/frontend/src/Components/Utilities/TopMenu/StateManagementSuite.tsx
@@ -50,7 +50,8 @@ function StateManagementSuite() {
   }, []);
 
   const loadSavedState = async (name: string) => {
-    const res = await (fetch(`${import.meta.env.VITE_QUERY_URL}state?name=${name}`));
+    const params = new URLSearchParams({ name });
+    const res = await (fetch(`${import.meta.env.VITE_QUERY_URL}state?${params}`));
     const result = await res.json();
     store.provenance.importState(result.definition);
   };


### PR DESCRIPTION
## Summary
- Treat created state/share responses as successful in the frontend and keep saved-state names in sync after create/rename
- Encode state names and form payloads for save/load/share requests
- Parse JSON PUT/DELETE bodies in the state API, preserve public visibility on quick-save, and return explicit 201 statuses for created resources
- Add backend regression coverage for state create/load/update/share behavior

## Verification
- PASS: poetry run python manage.py test api.tests.test_auth api.tests.test_state --settings=api.test_settings
- PASS: git diff --check
- BLOCKED: poetry run python manage.py test api.tests --settings=api.test_settings fails on existing api.tests.test_saml import error: SanguineSaml2Backend is not exported from api.saml
- BLOCKED: yarn tsc --noEmit fails on existing TypeScript 6 deprecation settings in tsconfig.json
- BLOCKED: yarn lint fails because installed ESLint is 9.36.0 but the repo uses legacy .eslintrc config